### PR TITLE
fix(artists): fetch the public profile with no-store, deduped per request

### DIFF
--- a/lib/recoup/__tests__/getArtistProfile.test.ts
+++ b/lib/recoup/__tests__/getArtistProfile.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import getArtistProfile from "@/lib/recoup/getArtistProfile";
 
+const { cacheMock } = vi.hoisted(() => ({ cacheMock: vi.fn() }));
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  cacheMock.mockImplementation(
+    <T extends (...args: never[]) => unknown>(fn: T) => fn,
+  );
+  return { ...actual, cache: cacheMock };
+});
+
 const ARTIST = "5e9eca42-b5af-47ef-83c9-3e498506a3d6";
 
 const profile = {
@@ -15,7 +24,12 @@ const profile = {
     },
   ],
   catalogs: [
-    { id: "cat_1", name: "Brauxelion Catalog", song_count: 24, updated_at: "2026-08-01" },
+    {
+      id: "cat_1",
+      name: "Brauxelion Catalog",
+      song_count: 24,
+      updated_at: "2026-08-01",
+    },
   ],
 };
 
@@ -30,7 +44,7 @@ afterEach(() => {
 });
 
 describe("getArtistProfile", () => {
-  it("fetches the public profile endpoint with no auth header and ISR caching", async () => {
+  it("fetches the public profile endpoint with no auth header and no store", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(JSON.stringify(profile), { status: 200 }),
     );
@@ -40,21 +54,33 @@ describe("getArtistProfile", () => {
     expect(result).toEqual(profile);
     const [url, init] = vi.mocked(global.fetch).mock.calls[0];
     expect(String(url)).toMatch(new RegExp(`/api/artists/${ARTIST}/profile$`));
-    expect(init).toEqual({ next: { revalidate: 300 } });
+    // The api answers fresh on every request (recoupable/app#1984); a data
+    // cache entry here would put the staleness back.
+    expect(init).toEqual({ cache: "no-store" });
+  });
+
+  it("is wrapped in React cache() so generateMetadata and the page share one fetch per request", () => {
+    expect(cacheMock).toHaveBeenCalledTimes(1);
+    expect(cacheMock.mock.calls[0][0]).toBeInstanceOf(Function);
   });
 
   it("returns null on 404 so the page can render notFound()", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      new Response(JSON.stringify({ status: "error", message: "Artist not found" }), {
-        status: 404,
-      }),
+      new Response(
+        JSON.stringify({ status: "error", message: "Artist not found" }),
+        {
+          status: 404,
+        },
+      ),
     );
 
     expect(await getArtistProfile(ARTIST)).toBeNull();
   });
 
   it("throws on any other non-ok status", async () => {
-    vi.mocked(global.fetch).mockResolvedValue(new Response("nope", { status: 500 }));
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("nope", { status: 500 }),
+    );
 
     await expect(getArtistProfile(ARTIST)).rejects.toThrow(/500/);
   });

--- a/lib/recoup/getArtistProfile.ts
+++ b/lib/recoup/getArtistProfile.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { NEW_API_BASE_URL } from "@/lib/consts";
 
 export interface ArtistProfileSocial {
@@ -41,23 +42,27 @@ export interface ArtistProfile {
 /**
  * GET /api/artists/{id}/profile on the Recoup API — the public artist profile.
  * No auth: the endpoint is deliberately unauthenticated, so this is safe to
- * call from a public server component. Cached for 5 minutes via ISR to match
- * the endpoint's own s-maxage.
+ * call from a public server component. Fetched with `no-store` so a write is
+ * visible on the next page load (recoupable/app#1984); React `cache()` dedupes
+ * the metadata and page calls into one request per render.
  *
  * @param artistId - The artist's account id.
  * @returns The profile, or null on 404 (unknown id or not an artist).
  */
-async function getArtistProfile(artistId: string): Promise<ArtistProfile | null> {
-  const response = await fetch(`${NEW_API_BASE_URL}/api/artists/${artistId}/profile`, {
-    next: { revalidate: 300 },
-  });
-
-  if (response.status === 404) return null;
-  if (!response.ok) {
-    throw new Error(`Failed to fetch artist profile: ${response.status}`);
-  }
-
-  return response.json();
-}
+const getArtistProfile = cache(
+  async (artistId: string): Promise<ArtistProfile | null> => {
+    const response = await fetch(
+      `${NEW_API_BASE_URL}/api/artists/${artistId}/profile`,
+      {
+        cache: "no-store",
+      },
+    );
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(`Failed to fetch artist profile: ${response.status}`);
+    }
+    return response.json();
+  },
+);
 
 export default getArtistProfile;


### PR DESCRIPTION
Implements the chat row of recoupable/app#1984. Pairs with recoupable/api#862 (removes the api-side `Cache-Control`); the page is fresh once both are on `main`.

## What changed

- `lib/recoup/getArtistProfile.ts`: `next: { revalidate: 300 }` → `cache: "no-store"`. This was chat's only cached fetcher and it doubled the staleness window on the public artist page.
- Wrapped in React `cache()`, so `generateMetadata` and the page component share one api call per render instead of two.
- Docstring describes the current behaviour.

## Tests

RED → GREEN in `lib/recoup/__tests__/getArtistProfile.test.ts`: the fetch is issued with `{ cache: "no-store" }` (failed against `revalidate: 300`), and the fetcher is registered through React `cache()` (mocked `react.cache`, asserted one registration). 404 → null and non-ok → throw unchanged. Full suite, `tsc` and eslint: see the checks comment.

## Preview verification

Chat previews read the api `test` branch, so the end-to-end walk (api write → one reload shows it) is posted after api#862 merges and `test` is synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtczxqHwvK1J6VMNnuukXL


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches the public artist profile with `no-store` so a data write shows up on the next page load instead of after a second 5-minute staleness window.

- Wraps the fetcher in React `cache()` so `generateMetadata` and the page component share one API call per render instead of two.
- Pairs with `recoupable/api#862` (removes the API-side `Cache-Control`); the page is fresh on `main` once both merge.
- Tests assert the fetch sends `cache: "no-store"` and the fetcher is registered through React `cache()`; 404 → null and non-ok → throw behavior is unchanged.

<sup>Written for commit bd766d8bcefce8a3daa05f3bd1f24e0892d2c521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artist profile information now reflects the latest available data without relying on stale cached responses.
  * Existing handling for missing profiles and other request errors remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->