### PR TITLE
chore: regenerate database.types after account_workspace_ids was dropped

### DIFF
--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -397,42 +397,6 @@ export type Database = {
           },
         ];
       };
-      account_workspace_ids: {
-        Row: {
-          account_id: string | null;
-          id: string;
-          updated_at: string | null;
-          workspace_id: string | null;
-        };
-        Insert: {
-          account_id?: string | null;
-          id?: string;
-          updated_at?: string | null;
-          workspace_id?: string | null;
-        };
-        Update: {
-          account_id?: string | null;
-          id?: string;
-          updated_at?: string | null;
-          workspace_id?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "account_workspace_ids_account_id_fkey";
-            columns: ["account_id"];
-            isOneToOne: false;
-            referencedRelation: "accounts";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "account_workspace_ids_workspace_id_fkey";
-            columns: ["workspace_id"];
-            isOneToOne: false;
-            referencedRelation: "accounts";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       accounts: {
         Row: {
           id: string;


### PR DESCRIPTION
Closes out the database item of recoupable/app#1979 on the app side: `types/database.types.ts` regenerated from the live schema after database#59 dropped `account_workspace_ids` (migration `20260827000000`, applied to prod 2026-08-27). chat#1991 deliberately left these generated entries for this regen.

## What changed

Generated with the Supabase TypeScript generator against project `godremdqwajrwazhbrue` (public schema, same output as `pnpm update-types`) and formatted with prettier; no hand edits.

Table-level delta: removed: account_workspace_ids: {;

`account_workspace_ids` no longer appears anywhere in the file; nothing in the app referenced it since chat#1991.

## Checks

`tsc --noEmit` clean on this head; no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtczxqHwvK1J6VMNnuukXL


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `account_workspace_ids` table types from `types/database.types.ts` after the database migration dropped that table, closing out the database item in app#1979. The file was regenerated from the live schema with no hand edits, and nothing in the codebase referenced the removed table, so there are no runtime side effects.

<sup>Written for commit de9a7ab7686321ff75813b9ddf7d8418a771dbcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

