### PR TITLE
feat(music): breadcrumb from the song page back to /music

### DIFF
--- a/components/SongPage/SongBreadcrumb.tsx
+++ b/components/SongPage/SongBreadcrumb.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from "@/components/ui/breadcrumb";
+
+/**
+ * Way back from a song page to the gallery, shaped like `TaskBreadcrumb`.
+ * Rendered in every state of the page, so a visitor who cannot see the song
+ * still has somewhere to go.
+ */
+const SongBreadcrumb = ({ title }: { title: string }) => (
+  <Breadcrumb>
+    <BreadcrumbList>
+      <BreadcrumbItem>
+        <BreadcrumbLink asChild>
+          <Link href="/music">Music</Link>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage className="truncate">{title}</BreadcrumbPage>
+      </BreadcrumbItem>
+    </BreadcrumbList>
+  </Breadcrumb>
+);
+
+export default SongBreadcrumb;

--- a/components/SongPage/SongDetail.tsx
+++ b/components/SongPage/SongDetail.tsx
@@ -1,78 +1,30 @@
 "use client";
 
-import { Skeleton } from "@/components/ui/skeleton";
-import MusicDetailBody from "@/components/MusicPage/MusicDetailBody";
-import MusicStatusPill from "@/components/MusicPage/MusicStatusPill";
 import useMusicGeneration from "@/hooks/useMusicGeneration";
-import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
+import SongBreadcrumb from "./SongBreadcrumb";
+import SongDetailContent from "./SongDetailContent";
 
 /**
  * One song at its own URL.
  *
- * Starts from an id alone — there is no card summary to render from — so it
- * shows a skeleton until the read lands.
- *
- * A 403 is rendered as a sentence rather than an error. The URL is meant to be
- * passed around, so it will reach people who cannot open it: a forwarded link,
- * someone outside the org. "You do not have access" is the truthful answer and
- * reads nothing like a broken page.
+ * Starts from an id alone, so the content shows a skeleton until the read
+ * lands. The breadcrumb is outside the read states on purpose: the page is
+ * reached from links (a Telegram notification, a pasted URL), and the way
+ * back to the gallery must exist before the song loads and when it cannot be
+ * shown at all (recoupable/app#1999).
  */
 const SongDetail = ({ generationId }: { generationId: string }) => {
   const { data, isLoading, error } = useMusicGeneration(generationId, true);
   const generation = data?.generation;
 
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <Skeleton className="h-7 w-40" />
-        <Skeleton className="h-24 w-full rounded-lg" />
-        <Skeleton className="h-40 w-full rounded-lg" />
-      </div>
-    );
-  }
-
-  if (error) {
-    const status = error instanceof MusicGenerationRequestError ? error.status : null;
-
-    if (status === 403) {
-      return (
-        <p className="text-sm text-muted-foreground" data-testid="song-no-access">
-          You do not have access to this song. Ask whoever shared it to add you to the
-          workspace it belongs to.
-        </p>
-      );
-    }
-
-    if (status === 404) {
-      return (
-        <p className="text-sm text-muted-foreground" data-testid="song-not-found">
-          This song does not exist. It may have been deleted.
-        </p>
-      );
-    }
-
-    return (
-      <p className="text-sm text-destructive" data-testid="song-error">
-        Could not load this song. Refresh to try again.
-      </p>
-    );
-  }
-
-  if (!generation) return null;
-
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h1 className="font-heading text-xl font-bold">Song details</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Generated {new Date(generation.created_at).toLocaleString()}
-          </p>
-        </div>
-        <MusicStatusPill status={generation.status} />
-      </div>
-
-      <MusicDetailBody generation={generation} seed={generation.seed} seedPending={false} />
+      <SongBreadcrumb title={generation?.prompt ?? "Song"} />
+      <SongDetailContent
+        generation={generation}
+        isLoading={isLoading}
+        error={error}
+      />
     </div>
   );
 };

--- a/components/SongPage/SongDetailContent.tsx
+++ b/components/SongPage/SongDetailContent.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import MusicDetailBody from "@/components/MusicPage/MusicDetailBody";
+import MusicStatusPill from "@/components/MusicPage/MusicStatusPill";
+import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
+import type { MusicGenerationDetail } from "@/types/Music";
+
+/**
+ * The body of the song page for one read state: skeleton, one of three
+ * explained errors, or the song itself.
+ *
+ * A 403 is rendered as a sentence rather than an error. The URL is meant to be
+ * passed around, so it will reach people who cannot open it: a forwarded link,
+ * someone outside the org. "You do not have access" is the truthful answer and
+ * reads nothing like a broken page.
+ */
+const SongDetailContent = ({
+  generation,
+  isLoading,
+  error,
+}: {
+  generation: MusicGenerationDetail | undefined;
+  isLoading: boolean;
+  error: unknown;
+}) => {
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    const status =
+      error instanceof MusicGenerationRequestError ? error.status : null;
+
+    if (status === 403) {
+      return (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="song-no-access"
+        >
+          You do not have access to this song. Ask whoever shared it to add you
+          to the workspace it belongs to.
+        </p>
+      );
+    }
+
+    if (status === 404) {
+      return (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="song-not-found"
+        >
+          This song does not exist. It may have been deleted.
+        </p>
+      );
+    }
+
+    return (
+      <p className="text-sm text-destructive" data-testid="song-error">
+        Could not load this song. Refresh to try again.
+      </p>
+    );
+  }
+
+  if (!generation) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="font-heading text-xl font-bold">Song details</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Generated {new Date(generation.created_at).toLocaleString()}
+          </p>
+        </div>
+        <MusicStatusPill status={generation.status} />
+      </div>
+
+      <MusicDetailBody
+        generation={generation}
+        seed={generation.seed}
+        seedPending={false}
+      />
+    </div>
+  );
+};
+
+export default SongDetailContent;

--- a/components/SongPage/__tests__/SongDetail.test.tsx
+++ b/components/SongPage/__tests__/SongDetail.test.tsx
@@ -8,10 +8,23 @@ import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
 import type { MusicGenerationDetail } from "@/types/Music";
 
 vi.mock("@/hooks/useMusicGeneration", () => ({ default: vi.fn() }));
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
 const ID = "11111111-2222-4333-8444-555555555555";
 
-const detail = (over: Partial<MusicGenerationDetail> = {}): MusicGenerationDetail => ({
+const detail = (
+  over: Partial<MusicGenerationDetail> = {},
+): MusicGenerationDetail => ({
   id: ID,
   status: "completed",
   prompt: "Genre: lo-fi soul. BPM: 82.",
@@ -34,11 +47,18 @@ describe("SongDetail", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("renders the song once the read lands", () => {
-    mock({ data: { status: "success", generation: detail() }, isLoading: false, error: null });
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
 
     render(<SongDetail generationId={ID} />);
 
-    expect(screen.getByText("Genre: lo-fi soul. BPM: 82.")).toBeDefined();
+    // The prompt also names the song in the breadcrumb, so read the block by id.
+    expect(screen.getByTestId("music-detail-prompt").textContent).toBe(
+      "Genre: lo-fi soul. BPM: 82.",
+    );
     expect(screen.getByTestId("music-detail-seed").textContent).toBe("42");
   });
 
@@ -54,7 +74,11 @@ describe("SongDetail", () => {
   it("explains a 403 instead of showing an error", () => {
     // The URL is meant to be passed around, so it will reach people who cannot
     // open it. That must read as an answer, not a fault.
-    mock({ data: undefined, isLoading: false, error: new MusicGenerationRequestError(403, "no") });
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: new MusicGenerationRequestError(403, "no"),
+    });
 
     render(<SongDetail generationId={ID} />);
 
@@ -63,7 +87,11 @@ describe("SongDetail", () => {
   });
 
   it("distinguishes a missing song from one you cannot see", () => {
-    mock({ data: undefined, isLoading: false, error: new MusicGenerationRequestError(404, "no") });
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: new MusicGenerationRequestError(404, "no"),
+    });
 
     render(<SongDetail generationId={ID} />);
 
@@ -96,14 +124,46 @@ describe("SongDetail", () => {
 
     render(<SongDetail generationId={ID} />);
 
-    expect(screen.getByText("Lyrics structure tags were rejected.")).toBeDefined();
+    expect(
+      screen.getByText("Lyrics structure tags were rejected."),
+    ).toBeDefined();
   });
 
   it("renders exactly one page heading", () => {
-    mock({ data: { status: "success", generation: detail() }, isLoading: false, error: null });
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
 
     render(<SongDetail generationId={ID} />);
 
     expect(screen.getAllByText("Song details")).toHaveLength(1);
+  });
+
+  // The page is reached from a Telegram link, so the way back to the gallery
+  // has to be on the page itself (recoupable/app#1999).
+  it("links back to /music in a breadcrumb, naming the song by its prompt", () => {
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
+    render(<SongDetail generationId={ID} />);
+    const crumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(crumb.querySelector('a[href="/music"]')?.textContent).toBe("Music");
+    expect(crumb.textContent).toContain("Genre: lo-fi soul. BPM: 82.");
+  });
+
+  it("keeps the way back even when the song cannot be shown", () => {
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: new MusicGenerationRequestError(403, "no"),
+    });
+    render(<SongDetail generationId={ID} />);
+    const crumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(crumb.querySelector('a[href="/music"]')).not.toBeNull();
+    expect(crumb.textContent).toContain("Song");
   });
 });


### PR DESCRIPTION
Implements the **breadcrumb row** of recoupable/app#1999: `/music/{id}` had no way back to the gallery.

## What changed

- `components/SongPage/SongBreadcrumb.tsx`: `Music › {prompt}` on the shadcn `Breadcrumb` primitives (`@/components/ui/breadcrumb`), the same shape as `TaskBreadcrumb` / `RunBreadcrumb`; "Music" links to `/music`.
- `SongDetail` renders the breadcrumb **outside** the read states, so it is there during the skeleton and on the 403 / 404 / error screens (label falls back to "Song" until the prompt is known). The read states moved verbatim into `SongDetailContent` so both files stay under 100 lines.

## Tests

RED → GREEN in `SongDetail.test.tsx`: the loaded page has a breadcrumb `navigation` whose `/music` link reads "Music" and whose current crumb is the prompt; the 403 state keeps the `/music` link. The existing "renders the song" test now reads the prompt block by test id, since the prompt also appears in the crumb. `components/SongPage` + `components/MusicPage` suites 35/35, `tsc --noEmit` + eslint clean.

## Preview verification

Posted as a comment: screenshot of the breadcrumb on a loaded song and on the no-access state, and the crumb navigating back to `/music`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtczxqHwvK1J6VMNnuukXL


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the breadcrumb row of recoupable/app#1999 to the song page: a "Music" link back to `/music`. Previously the page had no route back to the gallery; the crumb now renders in every page state, naming the song by its prompt once loaded and falling back to "Song" while the prompt is unknown.

**Refactors**
- The read states (loading skeleton, 403/404 errors, loaded song) moved into `SongDetailContent` so `SongDetail` stays small.

<sup>Written for commit 971df2bc696b32f7ea687fe3f1a31411aba45a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

