### PR TITLE
feat(music): play and download a song from its page

### DIFF
--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -2,13 +2,9 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Download } from "lucide-react";
 import MusicStatusPill from "./MusicStatusPill";
+import MusicPlayerRow from "./MusicPlayerRow";
 import { formatDuration } from "@/lib/music/formatDuration";
-import {
-  musicDownloadFilename,
-  musicDownloadUrl,
-} from "@/lib/music/musicDownloadUrl";
 import type { MusicGeneration } from "@/types/Music";
 
 const MusicGenerationCard = ({
@@ -23,10 +19,6 @@ const MusicGenerationCard = ({
   // The API returns no title: the prompt is what the user wrote and what
   // identifies the song to them.
   const title = generation.prompt;
-  const downloadHref = musicDownloadUrl(
-    generation.audio_url,
-    musicDownloadFilename(title, generation.audio_url ?? ""),
-  );
 
   return (
     // min-w-0 because a grid item defaults to min-width:auto and will not
@@ -57,40 +49,8 @@ const MusicGenerationCard = ({
       </div>
 
       {isCompleted && (
-        // The player and the download live inside a clickable card, so their
-        // clicks stop here. Without this, pressing play or saving a song would
-        // also pop the detail dialog open.
-        <div
-          onClick={(event) => event.stopPropagation()}
-          className="mt-3 flex items-center gap-2 min-w-0"
-        >
-          {/* The native player carries play, seek, and volume, and stays
-                keyboard accessible without us rebuilding any of it.
-                preload="metadata" fetches only the header, a few KB, so the
-                scrubber shows the real length straight away. With "none" it read
-                0:00 / 0:00 next to a Completed pill, which looks like an empty
-                file until you press play.
-
-                flex-1 with a zero basis rather than w-full: a native audio
-                element has a wide intrinsic width and a flex item will not
-                shrink below its content, so w-full rendered the card 719px wide
-                inside a 342px grid cell on mobile. */}
-          <audio
-            controls
-            preload="metadata"
-            src={generation.audio_url ?? undefined}
-            className="h-9 min-w-0 flex-1 basis-0"
-          >
-            <track kind="captions" />
-          </audio>
-          <a
-            href={downloadHref ?? undefined}
-            download
-            aria-label={`Download ${title}`}
-            className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"
-          >
-            <Download className="size-4" />
-          </a>
+        <div className="mt-3">
+          <MusicPlayerRow generation={generation} />
         </div>
       )}
 

--- a/components/MusicPage/MusicPlayerRow.tsx
+++ b/components/MusicPage/MusicPlayerRow.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Download } from "lucide-react";
+import {
+  musicDownloadFilename,
+  musicDownloadUrl,
+} from "@/lib/music/musicDownloadUrl";
+import type { MusicGeneration } from "@/types/Music";
+
+/**
+ * The native player and the download for a completed song; nothing for any
+ * other status. Shared by the gallery card and the song page so the two
+ * cannot drift (recoupable/app#1999).
+ *
+ * The native player carries play, seek, and volume, and stays keyboard
+ * accessible without us rebuilding any of it. preload="metadata" fetches only
+ * the header, a few KB, so the scrubber shows the real length straight away;
+ * with "none" it read 0:00 / 0:00 next to a Completed pill, which looks like an
+ * empty file until you press play. flex-1 with a zero basis rather than w-full:
+ * a native audio element has a wide intrinsic width and a flex item will not
+ * shrink below its content, so w-full rendered the card 719px wide inside a
+ * 342px grid cell on mobile.
+ *
+ * Clicks stop here: inside the card the surface around this row navigates to
+ * the song page, and pressing play or saving a song must not.
+ */
+const MusicPlayerRow = ({ generation }: { generation: MusicGeneration }) => {
+  if (generation.status !== "completed" || !generation.audio_url) return null;
+  // The API returns no title: the prompt is what the user wrote and what
+  // identifies the song to them.
+  const title = generation.prompt;
+  const downloadHref = musicDownloadUrl(
+    generation.audio_url,
+    musicDownloadFilename(title, generation.audio_url),
+  );
+
+  return (
+    <div
+      onClick={(event) => event.stopPropagation()}
+      className="flex items-center gap-2 min-w-0"
+    >
+      <audio
+        controls
+        preload="metadata"
+        src={generation.audio_url}
+        className="h-9 min-w-0 flex-1 basis-0"
+      >
+        <track kind="captions" />
+      </audio>
+      <a
+        href={downloadHref ?? undefined}
+        download
+        aria-label={`Download ${title}`}
+        className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"
+      >
+        <Download className="size-4" />
+      </a>
+    </div>
+  );
+};
+
+export default MusicPlayerRow;

--- a/components/SongPage/SongBreadcrumb.tsx
+++ b/components/SongPage/SongBreadcrumb.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from "@/components/ui/breadcrumb";
+
+/**
+ * Way back from a song page to the gallery, shaped like `TaskBreadcrumb`.
+ * Rendered in every state of the page, so a visitor who cannot see the song
+ * still has somewhere to go.
+ */
+const SongBreadcrumb = ({ title }: { title: string }) => (
+  <Breadcrumb>
+    <BreadcrumbList>
+      <BreadcrumbItem>
+        <BreadcrumbLink asChild>
+          <Link href="/music">Music</Link>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage className="truncate">{title}</BreadcrumbPage>
+      </BreadcrumbItem>
+    </BreadcrumbList>
+  </Breadcrumb>
+);
+
+export default SongBreadcrumb;

--- a/components/SongPage/SongDetail.tsx
+++ b/components/SongPage/SongDetail.tsx
@@ -1,78 +1,30 @@
 "use client";
 
-import { Skeleton } from "@/components/ui/skeleton";
-import MusicDetailBody from "@/components/MusicPage/MusicDetailBody";
-import MusicStatusPill from "@/components/MusicPage/MusicStatusPill";
 import useMusicGeneration from "@/hooks/useMusicGeneration";
-import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
+import SongBreadcrumb from "./SongBreadcrumb";
+import SongDetailContent from "./SongDetailContent";
 
 /**
  * One song at its own URL.
  *
- * Starts from an id alone — there is no card summary to render from — so it
- * shows a skeleton until the read lands.
- *
- * A 403 is rendered as a sentence rather than an error. The URL is meant to be
- * passed around, so it will reach people who cannot open it: a forwarded link,
- * someone outside the org. "You do not have access" is the truthful answer and
- * reads nothing like a broken page.
+ * Starts from an id alone, so the content shows a skeleton until the read
+ * lands. The breadcrumb is outside the read states on purpose: the page is
+ * reached from links (a Telegram notification, a pasted URL), and the way
+ * back to the gallery must exist before the song loads and when it cannot be
+ * shown at all (recoupable/app#1999).
  */
 const SongDetail = ({ generationId }: { generationId: string }) => {
   const { data, isLoading, error } = useMusicGeneration(generationId, true);
   const generation = data?.generation;
 
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <Skeleton className="h-7 w-40" />
-        <Skeleton className="h-24 w-full rounded-lg" />
-        <Skeleton className="h-40 w-full rounded-lg" />
-      </div>
-    );
-  }
-
-  if (error) {
-    const status = error instanceof MusicGenerationRequestError ? error.status : null;
-
-    if (status === 403) {
-      return (
-        <p className="text-sm text-muted-foreground" data-testid="song-no-access">
-          You do not have access to this song. Ask whoever shared it to add you to the
-          workspace it belongs to.
-        </p>
-      );
-    }
-
-    if (status === 404) {
-      return (
-        <p className="text-sm text-muted-foreground" data-testid="song-not-found">
-          This song does not exist. It may have been deleted.
-        </p>
-      );
-    }
-
-    return (
-      <p className="text-sm text-destructive" data-testid="song-error">
-        Could not load this song. Refresh to try again.
-      </p>
-    );
-  }
-
-  if (!generation) return null;
-
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h1 className="font-heading text-xl font-bold">Song details</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Generated {new Date(generation.created_at).toLocaleString()}
-          </p>
-        </div>
-        <MusicStatusPill status={generation.status} />
-      </div>
-
-      <MusicDetailBody generation={generation} seed={generation.seed} seedPending={false} />
+      <SongBreadcrumb title={generation?.prompt ?? "Song"} />
+      <SongDetailContent
+        generation={generation}
+        isLoading={isLoading}
+        error={error}
+      />
     </div>
   );
 };

--- a/components/SongPage/SongDetailContent.tsx
+++ b/components/SongPage/SongDetailContent.tsx
@@ -2,7 +2,8 @@
 
 import { Skeleton } from "@/components/ui/skeleton";
 import MusicDetailBody from "@/components/MusicPage/MusicDetailBody";
-import MusicStatusPill from "@/components/MusicPage/MusicStatusPill";
+import MusicPlayerRow from "@/components/MusicPage/MusicPlayerRow";
+import SongDetailHeader from "./SongDetailHeader";
 import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
 import type { MusicGenerationDetail } from "@/types/Music";
 
@@ -72,15 +73,14 @@ const SongDetailContent = ({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h1 className="font-heading text-xl font-bold">Song details</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Generated {new Date(generation.created_at).toLocaleString()}
-          </p>
-        </div>
-        <MusicStatusPill status={generation.status} />
-      </div>
+      <SongDetailHeader generation={generation} />
+      <MusicPlayerRow generation={generation} />
+      {(generation.status === "processing" ||
+        generation.status === "pending") && (
+        <p className="text-xs text-muted-foreground">
+          Generating. This usually takes 1 to 2 minutes.
+        </p>
+      )}
 
       <MusicDetailBody
         generation={generation}

--- a/components/SongPage/SongDetailContent.tsx
+++ b/components/SongPage/SongDetailContent.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import MusicDetailBody from "@/components/MusicPage/MusicDetailBody";
+import MusicStatusPill from "@/components/MusicPage/MusicStatusPill";
+import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
+import type { MusicGenerationDetail } from "@/types/Music";
+
+/**
+ * The body of the song page for one read state: skeleton, one of three
+ * explained errors, or the song itself.
+ *
+ * A 403 is rendered as a sentence rather than an error. The URL is meant to be
+ * passed around, so it will reach people who cannot open it: a forwarded link,
+ * someone outside the org. "You do not have access" is the truthful answer and
+ * reads nothing like a broken page.
+ */
+const SongDetailContent = ({
+  generation,
+  isLoading,
+  error,
+}: {
+  generation: MusicGenerationDetail | undefined;
+  isLoading: boolean;
+  error: unknown;
+}) => {
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    const status =
+      error instanceof MusicGenerationRequestError ? error.status : null;
+
+    if (status === 403) {
+      return (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="song-no-access"
+        >
+          You do not have access to this song. Ask whoever shared it to add you
+          to the workspace it belongs to.
+        </p>
+      );
+    }
+
+    if (status === 404) {
+      return (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="song-not-found"
+        >
+          This song does not exist. It may have been deleted.
+        </p>
+      );
+    }
+
+    return (
+      <p className="text-sm text-destructive" data-testid="song-error">
+        Could not load this song. Refresh to try again.
+      </p>
+    );
+  }
+
+  if (!generation) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="font-heading text-xl font-bold">Song details</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Generated {new Date(generation.created_at).toLocaleString()}
+          </p>
+        </div>
+        <MusicStatusPill status={generation.status} />
+      </div>
+
+      <MusicDetailBody
+        generation={generation}
+        seed={generation.seed}
+        seedPending={false}
+      />
+    </div>
+  );
+};
+
+export default SongDetailContent;

--- a/components/SongPage/SongDetailHeader.tsx
+++ b/components/SongPage/SongDetailHeader.tsx
@@ -1,0 +1,17 @@
+import MusicStatusPill from "@/components/MusicPage/MusicStatusPill";
+import type { MusicGeneration } from "@/types/Music";
+
+/** Title, generation time and status for the song page. */
+const SongDetailHeader = ({ generation }: { generation: MusicGeneration }) => (
+  <div className="flex items-start justify-between gap-3">
+    <div className="min-w-0">
+      <h1 className="font-heading text-xl font-bold">Song details</h1>
+      <p className="text-sm text-muted-foreground mt-0.5">
+        Generated {new Date(generation.created_at).toLocaleString()}
+      </p>
+    </div>
+    <MusicStatusPill status={generation.status} />
+  </div>
+);
+
+export default SongDetailHeader;

--- a/components/SongPage/__tests__/SongDetail.test.tsx
+++ b/components/SongPage/__tests__/SongDetail.test.tsx
@@ -8,10 +8,23 @@ import { MusicGenerationRequestError } from "@/lib/music/getMusicGeneration";
 import type { MusicGenerationDetail } from "@/types/Music";
 
 vi.mock("@/hooks/useMusicGeneration", () => ({ default: vi.fn() }));
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
 const ID = "11111111-2222-4333-8444-555555555555";
 
-const detail = (over: Partial<MusicGenerationDetail> = {}): MusicGenerationDetail => ({
+const detail = (
+  over: Partial<MusicGenerationDetail> = {},
+): MusicGenerationDetail => ({
   id: ID,
   status: "completed",
   prompt: "Genre: lo-fi soul. BPM: 82.",
@@ -34,11 +47,18 @@ describe("SongDetail", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("renders the song once the read lands", () => {
-    mock({ data: { status: "success", generation: detail() }, isLoading: false, error: null });
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
 
     render(<SongDetail generationId={ID} />);
 
-    expect(screen.getByText("Genre: lo-fi soul. BPM: 82.")).toBeDefined();
+    // The prompt also names the song in the breadcrumb, so read the block by id.
+    expect(screen.getByTestId("music-detail-prompt").textContent).toBe(
+      "Genre: lo-fi soul. BPM: 82.",
+    );
     expect(screen.getByTestId("music-detail-seed").textContent).toBe("42");
   });
 
@@ -54,7 +74,11 @@ describe("SongDetail", () => {
   it("explains a 403 instead of showing an error", () => {
     // The URL is meant to be passed around, so it will reach people who cannot
     // open it. That must read as an answer, not a fault.
-    mock({ data: undefined, isLoading: false, error: new MusicGenerationRequestError(403, "no") });
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: new MusicGenerationRequestError(403, "no"),
+    });
 
     render(<SongDetail generationId={ID} />);
 
@@ -63,7 +87,11 @@ describe("SongDetail", () => {
   });
 
   it("distinguishes a missing song from one you cannot see", () => {
-    mock({ data: undefined, isLoading: false, error: new MusicGenerationRequestError(404, "no") });
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: new MusicGenerationRequestError(404, "no"),
+    });
 
     render(<SongDetail generationId={ID} />);
 
@@ -96,14 +124,46 @@ describe("SongDetail", () => {
 
     render(<SongDetail generationId={ID} />);
 
-    expect(screen.getByText("Lyrics structure tags were rejected.")).toBeDefined();
+    expect(
+      screen.getByText("Lyrics structure tags were rejected."),
+    ).toBeDefined();
   });
 
   it("renders exactly one page heading", () => {
-    mock({ data: { status: "success", generation: detail() }, isLoading: false, error: null });
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
 
     render(<SongDetail generationId={ID} />);
 
     expect(screen.getAllByText("Song details")).toHaveLength(1);
+  });
+
+  // The page is reached from a Telegram link, so the way back to the gallery
+  // has to be on the page itself (recoupable/app#1999).
+  it("links back to /music in a breadcrumb, naming the song by its prompt", () => {
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
+    render(<SongDetail generationId={ID} />);
+    const crumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(crumb.querySelector('a[href="/music"]')?.textContent).toBe("Music");
+    expect(crumb.textContent).toContain("Genre: lo-fi soul. BPM: 82.");
+  });
+
+  it("keeps the way back even when the song cannot be shown", () => {
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: new MusicGenerationRequestError(403, "no"),
+    });
+    render(<SongDetail generationId={ID} />);
+    const crumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(crumb.querySelector('a[href="/music"]')).not.toBeNull();
+    expect(crumb.textContent).toContain("Song");
   });
 });

--- a/components/SongPage/__tests__/SongDetail.test.tsx
+++ b/components/SongPage/__tests__/SongDetail.test.tsx
@@ -166,4 +166,43 @@ describe("SongDetail", () => {
     expect(crumb.querySelector('a[href="/music"]')).not.toBeNull();
     expect(crumb.textContent).toContain("Song");
   });
+
+  // The page is where a Telegram link lands; the card had the player and the
+  // download, the page had neither (recoupable/app#1999).
+  it("plays and downloads a completed song, named after its prompt", () => {
+    mock({
+      data: { status: "success", generation: detail() },
+      isLoading: false,
+      error: null,
+    });
+    const { container } = render(<SongDetail generationId={ID} />);
+    expect(container.querySelector("audio")?.getAttribute("src")).toBe(
+      "https://cdn.example/a.wav",
+    );
+    const download = screen.getByRole("link", {
+      name: /download genre: lo-fi soul/i,
+    });
+    expect(download.getAttribute("href")).toContain(
+      "download=genre-lo-fi-soul-bpm-82.wav",
+    );
+  });
+
+  it("shows no player while a song is still generating", () => {
+    mock({
+      data: {
+        status: "success",
+        generation: detail({
+          status: "processing",
+          audio_url: null,
+          seed: null,
+        }),
+      },
+      isLoading: false,
+      error: null,
+    });
+    const { container } = render(<SongDetail generationId={ID} />);
+    expect(container.querySelector("audio")).toBeNull();
+    expect(screen.queryByRole("link", { name: /download/i })).toBeNull();
+    expect(screen.getByText(/Generating\. This usually takes/)).toBeDefined();
+  });
 });


### PR DESCRIPTION
Implements the **player + download row** of recoupable/app#1999: `/music/{id}`, where the Telegram link lands, could neither play nor download the song.

**Stacked on #2020** (breadcrumb): this branch includes that commit, so the diff here shows both until #2020 merges; merge #2020 first.

## What changed

- `components/MusicPage/MusicPlayerRow.tsx`: the card's controls row (native `<audio controls preload="metadata">` + the `musicDownloadUrl` anchor with the prompt-derived filename) as one shared component; renders nothing unless the song is completed with audio. Its `stopPropagation` stays, since inside the card the surrounding surface navigates.
- `MusicGenerationCard` renders `MusicPlayerRow` instead of its inline block (155 → 78 lines); its download tests pass unchanged.
- `SongDetailContent` renders `MusicPlayerRow` under the header, plus the card's "Generating. This usually takes 1 to 2 minutes." line for a pending/processing song (no polling, per the issue). The header moved to `SongDetailHeader` to keep the file under 100 lines.

## Tests

RED → GREEN in `SongDetail.test.tsx`: a completed song renders an `<audio>` with the stored `src` and a `Download …` link whose href carries `download=genre-lo-fi-soul-bpm-82.wav`; a processing song renders neither and shows the generating line. `components/SongPage` + `components/MusicPage` suites 37/37; `tsc --noEmit` + eslint clean.

## Preview verification

Posted as a comment: the page playing a real song and the download link, and the gallery card unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtczxqHwvK1J6VMNnuukXL


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds playback and download to the song page so songs reached from Telegram links can be played and saved, plus a breadcrumb back to the gallery.

- Extracts the card's player and download row into a shared `MusicPlayerRow`, used by both the gallery card and the song page so they cannot drift.
- Pending or processing songs show the card's "Generating" line instead of the player, with no polling.
- Renders the breadcrumb in every state, so the way back to `/music` exists before the song loads and when it cannot be shown.
- Moves the song page's load, error, and detail states into `SongDetailContent` and the header into `SongDetailHeader`.

<sup>Written for commit 584c3debd2eb0f3e4f9a2650d32298f999815189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

