### PR TITLE
feat(usage): /usage page with the account's charge line items in USD

### DIFF
--- a/app/usage/page.tsx
+++ b/app/usage/page.tsx
@@ -1,0 +1,5 @@
+import UsagePage from "@/components/UsagePage/UsagePage";
+
+const Usage = () => <UsagePage />;
+
+export default Usage;

--- a/components/Sidebar/UserProfileDropdown/CreditsUsage.tsx
+++ b/components/Sidebar/UserProfileDropdown/CreditsUsage.tsx
@@ -1,13 +1,8 @@
+import Link from "next/link";
 import { usePaymentProvider } from "@/providers/PaymentProvider";
 import { formatCreditsAsUsd } from "@/lib/credits/formatCreditsAsUsd";
 
-/**
- * Compact inline balance that lives inside the identity block.
- *
- * Shown as currency rather than a credit count. A count is only readable while
- * a credit happens to be worth a cent; at a micro-dollar the same balance
- * reads "3,330,000 / 3,330,000 credits" (chat#2000).
- */
+/** Remaining / monthly balance as currency, linking to the charges behind it. */
 const CreditsUsage = () => {
   const { totalCredits, credits, isLoading } = usePaymentProvider();
 
@@ -16,7 +11,9 @@ const CreditsUsage = () => {
       {isLoading ? (
         <span className="inline-block h-3 w-16 bg-muted animate-pulse rounded" />
       ) : (
-        `${formatCreditsAsUsd(credits)} / ${formatCreditsAsUsd(totalCredits)}`
+        <Link href="/usage" className="hover:underline" title="See what used your balance">
+          {`${formatCreditsAsUsd(credits)} / ${formatCreditsAsUsd(totalCredits)}`}
+        </Link>
       )}
     </p>
   );

--- a/components/Sidebar/UserProfileDropdown/__tests__/CreditsUsage.test.tsx
+++ b/components/Sidebar/UserProfileDropdown/__tests__/CreditsUsage.test.tsx
@@ -38,4 +38,12 @@ describe("CreditsUsage", () => {
 
     expect(container.querySelector(".animate-pulse")).not.toBeNull();
   });
+
+  it("links the balance to the usage page, where the charges behind it are listed", () => {
+    mock({ totalCredits: 3_330_000, credits: 1_200_000, isLoading: false });
+
+    render(<CreditsUsage />);
+
+    expect(screen.getByRole("link", { name: "$1.20 / $3.33" }).getAttribute("href")).toBe("/usage");
+  });
 });

--- a/components/UsagePage/UsageEmptyState.tsx
+++ b/components/UsagePage/UsageEmptyState.tsx
@@ -1,0 +1,7 @@
+const UsageEmptyState = () => (
+  <div className="rounded-2xl bg-card p-8 text-center shadow-[0_0_0_1px_var(--border)]">
+    <p className="text-sm text-muted-foreground">No charges this period yet.</p>
+  </div>
+);
+
+export default UsageEmptyState;

--- a/components/UsagePage/UsageLoadMore.tsx
+++ b/components/UsagePage/UsageLoadMore.tsx
@@ -1,0 +1,16 @@
+import { Button } from "@/components/ui/button";
+
+interface UsageLoadMoreProps {
+  onClick: () => void;
+  isLoading: boolean;
+}
+
+const UsageLoadMore = ({ onClick, isLoading }: UsageLoadMoreProps) => (
+  <div className="mt-4 flex justify-center">
+    <Button variant="outline" onClick={onClick} disabled={isLoading}>
+      {isLoading ? "Loading" : "Load more"}
+    </Button>
+  </div>
+);
+
+export default UsageLoadMore;

--- a/components/UsagePage/UsageNoAccess.tsx
+++ b/components/UsagePage/UsageNoAccess.tsx
@@ -1,6 +1,8 @@
 const UsageNoAccess = () => (
   <div className="rounded-2xl bg-card p-8 text-center shadow-[0_0_0_1px_var(--border)]">
-    <p className="text-sm text-muted-foreground">You do not have access to this account&apos;s usage.</p>
+    <p className="text-sm text-muted-foreground">
+      You do not have access to this account&apos;s usage.
+    </p>
   </div>
 );
 

--- a/components/UsagePage/UsageNoAccess.tsx
+++ b/components/UsagePage/UsageNoAccess.tsx
@@ -1,0 +1,7 @@
+const UsageNoAccess = () => (
+  <div className="rounded-2xl bg-card p-8 text-center shadow-[0_0_0_1px_var(--border)]">
+    <p className="text-sm text-muted-foreground">You do not have access to this account&apos;s usage.</p>
+  </div>
+);
+
+export default UsageNoAccess;

--- a/components/UsagePage/UsagePage.tsx
+++ b/components/UsagePage/UsagePage.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import useAccountUsage from "@/hooks/useAccountUsage";
+import isForbiddenError from "@/lib/usage/isForbiddenError";
+import UsagePageHeader from "./UsagePageHeader";
+import UsagePeriodSummary from "./UsagePeriodSummary";
+import UsageTable from "./UsageTable";
+import UsageEmptyState from "./UsageEmptyState";
+import UsageNoAccess from "./UsageNoAccess";
+import UsageSkeleton from "./UsageSkeleton";
+import UsageLoadMore from "./UsageLoadMore";
+
+const UsagePage = () => {
+  const { data, isLoading, error, hasNextPage, isFetchingNextPage, fetchNextPage } = useAccountUsage();
+  const first = data?.pages[0];
+  const events = data?.pages.flatMap((page) => page.events) ?? [];
+
+  return (
+    <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
+      <UsagePageHeader />
+      {isLoading && <UsageSkeleton />}
+      {!isLoading && isForbiddenError(error) && <UsageNoAccess />}
+      {!isLoading && error && !isForbiddenError(error) && (
+        <p className="text-sm text-muted-foreground">Usage could not be loaded. Try again in a moment.</p>
+      )}
+      {first && (
+        <>
+          <UsagePeriodSummary period={first.period} totalUsd={first.total_usd} />
+          {events.length === 0 ? <UsageEmptyState /> : <UsageTable events={events} />}
+          {hasNextPage && <UsageLoadMore onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default UsagePage;

--- a/components/UsagePage/UsagePage.tsx
+++ b/components/UsagePage/UsagePage.tsx
@@ -11,7 +11,14 @@ import UsageSkeleton from "./UsageSkeleton";
 import UsageLoadMore from "./UsageLoadMore";
 
 const UsagePage = () => {
-  const { data, isLoading, error, hasNextPage, isFetchingNextPage, fetchNextPage } = useAccountUsage();
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useAccountUsage();
   const first = data?.pages[0];
   const events = data?.pages.flatMap((page) => page.events) ?? [];
 
@@ -21,13 +28,27 @@ const UsagePage = () => {
       {isLoading && <UsageSkeleton />}
       {!isLoading && isForbiddenError(error) && <UsageNoAccess />}
       {!isLoading && error && !isForbiddenError(error) && (
-        <p className="text-sm text-muted-foreground">Usage could not be loaded. Try again in a moment.</p>
+        <p className="text-sm text-muted-foreground">
+          Usage could not be loaded. Try again in a moment.
+        </p>
       )}
       {first && (
         <>
-          <UsagePeriodSummary period={first.period} totalUsd={first.total_usd} />
-          {events.length === 0 ? <UsageEmptyState /> : <UsageTable events={events} />}
-          {hasNextPage && <UsageLoadMore onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />}
+          <UsagePeriodSummary
+            period={first.period}
+            totalUsd={first.total_usd}
+          />
+          {events.length === 0 ? (
+            <UsageEmptyState />
+          ) : (
+            <UsageTable events={events} />
+          )}
+          {hasNextPage && (
+            <UsageLoadMore
+              onClick={() => fetchNextPage()}
+              isLoading={isFetchingNextPage}
+            />
+          )}
         </>
       )}
     </div>

--- a/components/UsagePage/UsagePageHeader.tsx
+++ b/components/UsagePage/UsagePageHeader.tsx
@@ -1,0 +1,10 @@
+const UsagePageHeader = () => (
+  <div className="mb-6">
+    <h1 className="text-left font-heading text-3xl font-bold dark:text-white mb-4">Usage</h1>
+    <p className="text-lg text-muted-foreground text-left font-light font-sans max-w-2xl">
+      Every charge against your balance, newest first.
+    </p>
+  </div>
+);
+
+export default UsagePageHeader;

--- a/components/UsagePage/UsagePageHeader.tsx
+++ b/components/UsagePage/UsagePageHeader.tsx
@@ -1,6 +1,8 @@
 const UsagePageHeader = () => (
   <div className="mb-6">
-    <h1 className="text-left font-heading text-3xl font-bold dark:text-white mb-4">Usage</h1>
+    <h1 className="text-left font-heading text-3xl font-bold dark:text-white mb-4">
+      Usage
+    </h1>
     <p className="text-lg text-muted-foreground text-left font-light font-sans max-w-2xl">
       Every charge against your balance, newest first.
     </p>

--- a/components/UsagePage/UsagePeriodSummary.tsx
+++ b/components/UsagePage/UsagePeriodSummary.tsx
@@ -1,0 +1,20 @@
+import formatUsageDate from "@/lib/usage/formatUsageDate";
+
+interface UsagePeriodSummaryProps {
+  period: { from: string; to: string };
+  totalUsd: string;
+}
+
+/** The period the list covers and what it added up to, as currency. */
+const UsagePeriodSummary = ({ period, totalUsd }: UsagePeriodSummaryProps) => (
+  <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+    <p className="text-sm text-muted-foreground">
+      {formatUsageDate(period.from, false)} to {formatUsageDate(period.to, false)}
+    </p>
+    <p className="text-sm text-muted-foreground">
+      Total <span className="font-heading text-2xl font-bold text-foreground">{totalUsd}</span>
+    </p>
+  </div>
+);
+
+export default UsagePeriodSummary;

--- a/components/UsagePage/UsagePeriodSummary.tsx
+++ b/components/UsagePage/UsagePeriodSummary.tsx
@@ -9,10 +9,14 @@ interface UsagePeriodSummaryProps {
 const UsagePeriodSummary = ({ period, totalUsd }: UsagePeriodSummaryProps) => (
   <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
     <p className="text-sm text-muted-foreground">
-      {formatUsageDate(period.from, false)} to {formatUsageDate(period.to, false)}
+      {formatUsageDate(period.from, false)} to{" "}
+      {formatUsageDate(period.to, false)}
     </p>
     <p className="text-sm text-muted-foreground">
-      Total <span className="font-heading text-2xl font-bold text-foreground">{totalUsd}</span>
+      Total{" "}
+      <span className="font-heading text-2xl font-bold text-foreground">
+        {totalUsd}
+      </span>
     </p>
   </div>
 );

--- a/components/UsagePage/UsageRow.tsx
+++ b/components/UsagePage/UsageRow.tsx
@@ -7,11 +7,21 @@ import formatUsageTokens from "@/lib/usage/formatUsageTokens";
 /** One charge. The amount is the API's USD string; the micro-dollar integer is never shown. */
 const UsageRow = ({ event }: { event: UsageEvent }) => (
   <tr className="border-b border-border last:border-0 text-sm">
-    <td className="py-2.5 pr-3 whitespace-nowrap text-muted-foreground">{formatUsageDate(event.created_at)}</td>
-    <td className="py-2.5 px-3 whitespace-nowrap">{describeUsageEvent(event)}</td>
-    <td className="py-2.5 px-3 whitespace-nowrap">{describeUsageModel(event)}</td>
-    <td className="py-2.5 px-3 whitespace-nowrap text-muted-foreground">{formatUsageTokens(event)}</td>
-    <td className="py-2.5 pl-3 whitespace-nowrap text-right font-medium">{event.usd}</td>
+    <td className="py-2.5 pr-3 whitespace-nowrap text-muted-foreground">
+      {formatUsageDate(event.created_at)}
+    </td>
+    <td className="py-2.5 px-3 whitespace-nowrap">
+      {describeUsageEvent(event)}
+    </td>
+    <td className="hidden md:table-cell py-2.5 px-3 whitespace-nowrap">
+      {describeUsageModel(event)}
+    </td>
+    <td className="hidden md:table-cell py-2.5 px-3 whitespace-nowrap text-muted-foreground">
+      {formatUsageTokens(event)}
+    </td>
+    <td className="py-2.5 pl-3 whitespace-nowrap text-right font-medium">
+      {event.usd}
+    </td>
   </tr>
 );
 

--- a/components/UsagePage/UsageRow.tsx
+++ b/components/UsagePage/UsageRow.tsx
@@ -1,0 +1,18 @@
+import type { UsageEvent } from "@/lib/recoup/getAccountUsage";
+import describeUsageEvent from "@/lib/usage/describeUsageEvent";
+import describeUsageModel from "@/lib/usage/describeUsageModel";
+import formatUsageDate from "@/lib/usage/formatUsageDate";
+import formatUsageTokens from "@/lib/usage/formatUsageTokens";
+
+/** One charge. The amount is the API's USD string; the micro-dollar integer is never shown. */
+const UsageRow = ({ event }: { event: UsageEvent }) => (
+  <tr className="border-b border-border last:border-0 text-sm">
+    <td className="py-2.5 pr-3 whitespace-nowrap text-muted-foreground">{formatUsageDate(event.created_at)}</td>
+    <td className="py-2.5 px-3 whitespace-nowrap">{describeUsageEvent(event)}</td>
+    <td className="py-2.5 px-3 whitespace-nowrap">{describeUsageModel(event)}</td>
+    <td className="py-2.5 px-3 whitespace-nowrap text-muted-foreground">{formatUsageTokens(event)}</td>
+    <td className="py-2.5 pl-3 whitespace-nowrap text-right font-medium">{event.usd}</td>
+  </tr>
+);
+
+export default UsageRow;

--- a/components/UsagePage/UsageSkeleton.tsx
+++ b/components/UsagePage/UsageSkeleton.tsx
@@ -1,0 +1,9 @@
+const UsageSkeleton = () => (
+  <div className="space-y-2" aria-busy="true">
+    {[0, 1, 2, 3].map((i) => (
+      <div key={i} className="h-10 rounded-lg bg-muted animate-pulse" />
+    ))}
+  </div>
+);
+
+export default UsageSkeleton;

--- a/components/UsagePage/UsageTable.tsx
+++ b/components/UsagePage/UsageTable.tsx
@@ -1,0 +1,26 @@
+import type { UsageEvent } from "@/lib/recoup/getAccountUsage";
+import UsageRow from "./UsageRow";
+
+/** Line items, newest first. */
+const UsageTable = ({ events }: { events: UsageEvent[] }) => (
+  <div className="overflow-x-auto rounded-2xl bg-card p-4 sm:p-6 shadow-[0_0_0_1px_var(--border)]">
+    <table className="w-full">
+      <thead>
+        <tr className="border-b border-border text-left text-[11px] uppercase tracking-wide text-muted-foreground">
+          <th className="py-2 pr-3 font-medium">When</th>
+          <th className="py-2 px-3 font-medium">What ran</th>
+          <th className="py-2 px-3 font-medium">Model</th>
+          <th className="py-2 px-3 font-medium">Tokens</th>
+          <th className="py-2 pl-3 font-medium text-right">Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        {events.map((event) => (
+          <UsageRow key={event.id} event={event} />
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default UsageTable;

--- a/components/UsagePage/UsageTable.tsx
+++ b/components/UsagePage/UsageTable.tsx
@@ -1,7 +1,7 @@
 import type { UsageEvent } from "@/lib/recoup/getAccountUsage";
 import UsageRow from "./UsageRow";
 
-/** Line items, newest first. */
+/** Line items, newest first. Model and tokens collapse below `md` so the cost stays in view on a phone. */
 const UsageTable = ({ events }: { events: UsageEvent[] }) => (
   <div className="overflow-x-auto rounded-2xl bg-card p-4 sm:p-6 shadow-[0_0_0_1px_var(--border)]">
     <table className="w-full">
@@ -9,8 +9,8 @@ const UsageTable = ({ events }: { events: UsageEvent[] }) => (
         <tr className="border-b border-border text-left text-[11px] uppercase tracking-wide text-muted-foreground">
           <th className="py-2 pr-3 font-medium">When</th>
           <th className="py-2 px-3 font-medium">What ran</th>
-          <th className="py-2 px-3 font-medium">Model</th>
-          <th className="py-2 px-3 font-medium">Tokens</th>
+          <th className="hidden md:table-cell py-2 px-3 font-medium">Model</th>
+          <th className="hidden md:table-cell py-2 px-3 font-medium">Tokens</th>
           <th className="py-2 pl-3 font-medium text-right">Cost</th>
         </tr>
       </thead>

--- a/components/UsagePage/__tests__/UsagePage.test.tsx
+++ b/components/UsagePage/__tests__/UsagePage.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UsagePage from "@/components/UsagePage/UsagePage";
+import useAccountUsage from "@/hooks/useAccountUsage";
+
+vi.mock("@/hooks/useAccountUsage", () => ({ default: vi.fn() }));
+
+const EVENT = {
+  id: "3AANn3Ij9uF-zZIlW_zlP",
+  created_at: "2026-08-27T11:56:58.000Z",
+  source: "api",
+  agent_type: "main",
+  provider: "fal",
+  model_id: "minimax/music-3",
+  input_tokens: 0,
+  cached_input_tokens: 0,
+  output_tokens: 0,
+  tool_call_count: 0,
+  credits_deducted: 20000,
+  usd: "$0.02",
+};
+const CHAT_EVENT = {
+  ...EVENT,
+  id: "chat-1",
+  created_at: "2026-08-26T09:00:00.000Z",
+  source: "chat",
+  provider: "openai",
+  model_id: "gpt-5",
+  input_tokens: 1200,
+  output_tokens: 300,
+  credits_deducted: 12345,
+  usd: "$0.01",
+};
+const page = (events: (typeof EVENT)[], next_cursor: string | null = null) => ({
+  account_id: "acct",
+  period: { from: "2026-08-01T00:00:00.000Z", to: "2026-08-27T12:00:00.000Z" },
+  total_credits_deducted: 32345,
+  total_usd: "$0.03",
+  events,
+  next_cursor,
+});
+const mock = (v: Record<string, unknown>) => vi.mocked(useAccountUsage).mockReturnValue(v as never);
+const loaded = (pages: unknown[], extra: Record<string, unknown> = {}) =>
+  mock({
+    data: { pages },
+    isLoading: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    ...extra,
+  });
+
+describe("UsagePage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("lists each charge with its cost in dollars and never the raw credit integer", () => {
+    loaded([page([EVENT, CHAT_EVENT])]);
+
+    render(<UsagePage />);
+
+    expect(screen.getByText("$0.02")).toBeDefined();
+    expect(screen.getByText("api · main")).toBeDefined();
+    expect(screen.getByText("fal / minimax/music-3")).toBeDefined();
+    expect(screen.getByText("chat · main")).toBeDefined();
+    expect(screen.getByText("1,200 in · 300 out")).toBeDefined();
+    expect(screen.queryByText(/20000/)).toBeNull();
+    expect(screen.queryByText(/12345/)).toBeNull();
+  });
+
+  it("shows the period and its total as currency", () => {
+    loaded([page([EVENT])]);
+
+    render(<UsagePage />);
+
+    expect(screen.getByText("$0.03")).toBeDefined();
+    expect(screen.getByText(/Aug 1, 2026/)).toBeDefined();
+    expect(screen.queryByText(/32345/)).toBeNull();
+  });
+
+  it("shows an empty state when nothing was charged in the period", () => {
+    loaded([page([])]);
+
+    render(<UsagePage />);
+
+    expect(screen.getByText("No charges this period yet.")).toBeDefined();
+  });
+
+  it("explains a 403 instead of failing", () => {
+    mock({ data: undefined, isLoading: false, error: Object.assign(new Error("forbidden"), { status: 403 }) });
+
+    render(<UsagePage />);
+
+    expect(screen.getByText("You do not have access to this account's usage.")).toBeDefined();
+  });
+
+  it("shows a skeleton while loading", () => {
+    mock({ data: undefined, isLoading: true, error: null });
+
+    const { container } = render(<UsagePage />);
+
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+  });
+
+  it("offers Load more only while a next cursor exists, and asks for the next page", () => {
+    const fetchNextPage = vi.fn();
+    loaded([page([EVENT], "2026-08-27T11:56:58.000Z")], { hasNextPage: true, fetchNextPage });
+
+    render(<UsagePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders every loaded page in one list", () => {
+    loaded([page([EVENT], "c1"), page([CHAT_EVENT])]);
+
+    render(<UsagePage />);
+
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+});

--- a/components/UsagePage/__tests__/UsagePage.test.tsx
+++ b/components/UsagePage/__tests__/UsagePage.test.tsx
@@ -41,7 +41,8 @@ const page = (events: (typeof EVENT)[], next_cursor: string | null = null) => ({
   events,
   next_cursor,
 });
-const mock = (v: Record<string, unknown>) => vi.mocked(useAccountUsage).mockReturnValue(v as never);
+const mock = (v: Record<string, unknown>) =>
+  vi.mocked(useAccountUsage).mockReturnValue(v as never);
 const loaded = (pages: unknown[], extra: Record<string, unknown> = {}) =>
   mock({
     data: { pages },
@@ -89,11 +90,17 @@ describe("UsagePage", () => {
   });
 
   it("explains a 403 instead of failing", () => {
-    mock({ data: undefined, isLoading: false, error: Object.assign(new Error("forbidden"), { status: 403 }) });
+    mock({
+      data: undefined,
+      isLoading: false,
+      error: Object.assign(new Error("forbidden"), { status: 403 }),
+    });
 
     render(<UsagePage />);
 
-    expect(screen.getByText("You do not have access to this account's usage.")).toBeDefined();
+    expect(
+      screen.getByText("You do not have access to this account's usage."),
+    ).toBeDefined();
   });
 
   it("shows a skeleton while loading", () => {
@@ -106,7 +113,10 @@ describe("UsagePage", () => {
 
   it("offers Load more only while a next cursor exists, and asks for the next page", () => {
     const fetchNextPage = vi.fn();
-    loaded([page([EVENT], "2026-08-27T11:56:58.000Z")], { hasNextPage: true, fetchNextPage });
+    loaded([page([EVENT], "2026-08-27T11:56:58.000Z")], {
+      hasNextPage: true,
+      fetchNextPage,
+    });
 
     render(<UsagePage />);
 

--- a/components/UsagePage/__tests__/UsageTable.test.tsx
+++ b/components/UsagePage/__tests__/UsageTable.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import UsageTable from "@/components/UsagePage/UsageTable";
+
+const event = {
+  id: "evt-1",
+  created_at: "2026-08-27T13:47:00.000Z",
+  source: "api",
+  agent_type: "main",
+  provider: "fal",
+  model_id: "minimax/music-3",
+  input_tokens: 0,
+  cached_input_tokens: 0,
+  output_tokens: 0,
+  tool_call_count: 0,
+  credits_deducted: 120_000,
+  usd: "$0.12",
+};
+
+describe("UsageTable", () => {
+  it("keeps When, What ran and Cost on every width and collapses Model and Tokens below md", () => {
+    render(<UsageTable events={[event]} />);
+    const headers = screen.getAllByRole("columnheader");
+    const byText = (t: string) =>
+      headers.find((h) => h.textContent === t) as HTMLElement;
+    expect(byText("Model").className).toContain("hidden md:table-cell");
+    expect(byText("Tokens").className).toContain("hidden md:table-cell");
+    for (const t of ["When", "What ran", "Cost"])
+      expect(byText(t).className).not.toContain("hidden");
+    // the cells follow their headers
+    const cells = screen.getAllByRole("cell");
+    expect(cells[2].className).toContain("hidden md:table-cell");
+    expect(cells[3].className).toContain("hidden md:table-cell");
+    expect(cells[4].textContent).toBe("$0.12");
+    expect(cells[4].className).not.toContain("hidden");
+  });
+});

--- a/components/UsagePage/__tests__/UsageTable.test.tsx
+++ b/components/UsagePage/__tests__/UsageTable.test.tsx
@@ -23,14 +23,18 @@ describe("UsageTable", () => {
     const headers = screen.getAllByRole("columnheader");
     const byText = (t: string) =>
       headers.find((h) => h.textContent === t) as HTMLElement;
-    expect(byText("Model").className).toContain("hidden md:table-cell");
-    expect(byText("Tokens").className).toContain("hidden md:table-cell");
+    const collapses = (el: HTMLElement) => {
+      const classes = el.className.split(/\s+/);
+      return classes.includes("hidden") && classes.includes("md:table-cell");
+    };
+    expect(collapses(byText("Model"))).toBe(true);
+    expect(collapses(byText("Tokens"))).toBe(true);
     for (const t of ["When", "What ran", "Cost"])
       expect(byText(t).className).not.toContain("hidden");
     // the cells follow their headers
     const cells = screen.getAllByRole("cell");
-    expect(cells[2].className).toContain("hidden md:table-cell");
-    expect(cells[3].className).toContain("hidden md:table-cell");
+    expect(collapses(cells[2])).toBe(true);
+    expect(collapses(cells[3])).toBe(true);
     expect(cells[4].textContent).toBe("$0.12");
     expect(cells[4].className).not.toContain("hidden");
   });

--- a/components/UsagePage/__tests__/UsageTable.test.tsx
+++ b/components/UsagePage/__tests__/UsageTable.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import UsageTable from "@/components/UsagePage/UsageTable";

--- a/hooks/__tests__/useAccountUsage.test.tsx
+++ b/hooks/__tests__/useAccountUsage.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useAccountUsage from "@/hooks/useAccountUsage";
+import getAccountUsage from "@/lib/recoup/getAccountUsage";
+
+vi.mock("@/lib/recoup/getAccountUsage", () => ({ default: vi.fn() }));
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+}));
+vi.mock("@/providers/UserProvder", () => ({
+  useUserProvider: () => ({ userData: { account_id: "acct-1" } }),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {children}
+  </QueryClientProvider>
+);
+const page = (next_cursor: string | null) => ({
+  account_id: "acct-1",
+  period: { from: "a", to: "b" },
+  total_credits_deducted: 0,
+  total_usd: "$0.00",
+  events: [],
+  next_cursor,
+});
+
+describe("useAccountUsage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches the signed-in account's usage and pages with next_cursor", async () => {
+    vi.mocked(getAccountUsage).mockResolvedValueOnce(page("cur-1")).mockResolvedValueOnce(page(null));
+
+    const { result } = renderHook(() => useAccountUsage(), { wrapper });
+    await waitFor(() => expect(result.current.data?.pages).toHaveLength(1));
+
+    expect(getAccountUsage).toHaveBeenCalledWith("acct-1", "tok", { limit: 20, cursor: undefined });
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(result.current.data?.pages).toHaveLength(2));
+
+    expect(getAccountUsage).toHaveBeenLastCalledWith("acct-1", "tok", { limit: 20, cursor: "cur-1" });
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});

--- a/hooks/useAccountUsage.ts
+++ b/hooks/useAccountUsage.ts
@@ -1,0 +1,32 @@
+import { useInfiniteQuery, UseInfiniteQueryResult, InfiniteData } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import getAccountUsage, { AccountUsagePage } from "@/lib/recoup/getAccountUsage";
+import { useUserProvider } from "@/providers/UserProvder";
+
+const PAGE_SIZE = 20;
+
+/**
+ * The signed-in account's charge line items, newest first, one page per
+ * `next_cursor`. Auth and account come from the providers; nothing is passed in.
+ */
+const useAccountUsage = (): UseInfiniteQueryResult<InfiniteData<AccountUsagePage>> => {
+  const { userData } = useUserProvider();
+  const { getAccessToken, authenticated } = usePrivy();
+  const accountId = userData?.account_id as string | undefined;
+
+  return useInfiniteQuery({
+    queryKey: ["usage", accountId],
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Please sign in to load usage");
+      return getAccountUsage(accountId as string, accessToken, { limit: PAGE_SIZE, cursor: pageParam });
+    },
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    enabled: authenticated && !!accountId,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+};
+
+export default useAccountUsage;

--- a/lib/recoup/__tests__/getAccountUsage.test.ts
+++ b/lib/recoup/__tests__/getAccountUsage.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import getAccountUsage from "@/lib/recoup/getAccountUsage";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: () => "https://api.test",
+}));
+
+const ACCOUNT = "123e4567-e89b-12d3-a456-426614174000";
+const PAGE = {
+  account_id: ACCOUNT,
+  period: { from: "2026-08-01T00:00:00.000Z", to: "2026-08-27T12:00:00.000Z" },
+  total_credits_deducted: 20000,
+  total_usd: "$0.02",
+  events: [],
+  next_cursor: null,
+};
+
+describe("getAccountUsage", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("calls GET /api/accounts/{id}/usage with the bearer, limit and cursor", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => PAGE });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const page = await getAccountUsage(ACCOUNT, "tok", { limit: 20, cursor: "2026-08-27T11:00:00.000Z" });
+
+    expect(page).toEqual(PAGE);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      `https://api.test/api/accounts/${ACCOUNT}/usage?limit=20&cursor=2026-08-27T11%3A00%3A00.000Z`,
+    );
+    expect(init.headers).toEqual({ Authorization: "Bearer tok" });
+  });
+
+  it("omits the cursor on the first page", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => PAGE });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAccountUsage(ACCOUNT, "tok", { limit: 20 });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(`https://api.test/api/accounts/${ACCOUNT}/usage?limit=20`);
+  });
+
+  it("throws an error carrying the status so a 403 can render as no-access", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 403, json: async () => ({}) }));
+
+    await expect(getAccountUsage(ACCOUNT, "tok", { limit: 20 })).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/lib/recoup/getAccountUsage.ts
+++ b/lib/recoup/getAccountUsage.ts
@@ -1,0 +1,54 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+export interface UsageEvent {
+  id: string;
+  created_at: string;
+  source: string;
+  agent_type: string | null;
+  provider: string | null;
+  model_id: string | null;
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  tool_call_count: number;
+  /** Micro-dollars. Display `usd`; never print this integer. */
+  credits_deducted: number;
+  usd: string;
+}
+
+export interface AccountUsagePage {
+  account_id: string;
+  period: { from: string; to: string };
+  total_credits_deducted: number;
+  total_usd: string;
+  events: UsageEvent[];
+  next_cursor: string | null;
+}
+
+/**
+ * GET /api/accounts/{id}/usage on the Recoup API (Privy bearer): the charges
+ * behind the balance, newest first. The thrown error carries the HTTP status
+ * so a 403 can render as a no-access state rather than a failure.
+ */
+async function getAccountUsage(
+  accountId: string,
+  accessToken: string,
+  { limit, cursor }: { limit: number; cursor?: string },
+): Promise<AccountUsagePage> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor) params.set("cursor", cursor);
+
+  const response = await fetch(`${getClientApiBaseUrl()}/api/accounts/${accountId}/usage?${params}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    throw Object.assign(new Error(`Failed to fetch usage: ${response.status}`), {
+      status: response.status,
+    });
+  }
+
+  return response.json();
+}
+
+export default getAccountUsage;

--- a/lib/usage/__tests__/describeUsageEvent.test.ts
+++ b/lib/usage/__tests__/describeUsageEvent.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import describeUsageEvent from "@/lib/usage/describeUsageEvent";
+
+describe("describeUsageEvent", () => {
+  it("names the surface and the agent that ran", () => {
+    expect(describeUsageEvent({ source: "api", agent_type: "main" })).toBe("api · main");
+  });
+
+  it("falls back to the source alone when there is no agent type", () => {
+    expect(describeUsageEvent({ source: "chat", agent_type: null })).toBe("chat");
+  });
+});

--- a/lib/usage/__tests__/describeUsageModel.test.ts
+++ b/lib/usage/__tests__/describeUsageModel.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import describeUsageModel from "@/lib/usage/describeUsageModel";
+
+describe("describeUsageModel", () => {
+  it("joins provider and model", () => {
+    expect(describeUsageModel({ provider: "fal", model_id: "minimax/music-3" })).toBe("fal / minimax/music-3");
+  });
+
+  it("shows the model alone when the provider is unknown", () => {
+    expect(describeUsageModel({ provider: null, model_id: "gpt-5" })).toBe("gpt-5");
+  });
+
+  it("shows a dash for a charge with no model, such as a fixed-price research call", () => {
+    expect(describeUsageModel({ provider: null, model_id: null })).toBe("-");
+  });
+});

--- a/lib/usage/__tests__/formatUsageTokens.test.ts
+++ b/lib/usage/__tests__/formatUsageTokens.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import formatUsageTokens from "@/lib/usage/formatUsageTokens";
+
+describe("formatUsageTokens", () => {
+  it("lists input, cached and output tokens with thousands separators", () => {
+    expect(
+      formatUsageTokens({ input_tokens: 12345, cached_input_tokens: 1000, output_tokens: 678, tool_call_count: 2 }),
+    ).toBe("12,345 in · 1,000 cached · 678 out · 2 tools");
+  });
+
+  it("is a dash when nothing was metered, such as a fixed-price call", () => {
+    expect(
+      formatUsageTokens({ input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, tool_call_count: 0 }),
+    ).toBe("-");
+  });
+
+  it("omits zero parts", () => {
+    expect(
+      formatUsageTokens({ input_tokens: 10, cached_input_tokens: 0, output_tokens: 5, tool_call_count: 0 }),
+    ).toBe("10 in · 5 out");
+  });
+});

--- a/lib/usage/__tests__/isForbiddenError.test.ts
+++ b/lib/usage/__tests__/isForbiddenError.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import isForbiddenError from "@/lib/usage/isForbiddenError";
+
+describe("isForbiddenError", () => {
+  it("is true only for an error carrying status 403", () => {
+    expect(isForbiddenError(Object.assign(new Error("x"), { status: 403 }))).toBe(true);
+    expect(isForbiddenError(Object.assign(new Error("x"), { status: 500 }))).toBe(false);
+    expect(isForbiddenError(new Error("x"))).toBe(false);
+    expect(isForbiddenError(null)).toBe(false);
+  });
+});

--- a/lib/usage/describeUsageEvent.ts
+++ b/lib/usage/describeUsageEvent.ts
@@ -1,0 +1,5 @@
+/** "api · main": the surface a charge came from and the agent that ran. */
+const describeUsageEvent = ({ source, agent_type }: { source: string; agent_type: string | null }): string =>
+  agent_type ? `${source} · ${agent_type}` : source;
+
+export default describeUsageEvent;

--- a/lib/usage/describeUsageModel.ts
+++ b/lib/usage/describeUsageModel.ts
@@ -1,0 +1,7 @@
+/** "fal / minimax/music-3", the model alone, or a dash for a fixed-price charge. */
+const describeUsageModel = ({ provider, model_id }: { provider: string | null; model_id: string | null }): string => {
+  if (!model_id) return "-";
+  return provider ? `${provider} / ${model_id}` : model_id;
+};
+
+export default describeUsageModel;

--- a/lib/usage/formatUsageDate.ts
+++ b/lib/usage/formatUsageDate.ts
@@ -1,0 +1,11 @@
+/** "Aug 27, 2026, 11:56 AM" in the viewer's locale-neutral en-US form. */
+const formatUsageDate = (iso: string, withTime = true): string =>
+  new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    ...(withTime ? { hour: "numeric", minute: "2-digit" } : {}),
+    timeZone: "UTC",
+  });
+
+export default formatUsageDate;

--- a/lib/usage/formatUsageTokens.ts
+++ b/lib/usage/formatUsageTokens.ts
@@ -1,0 +1,20 @@
+interface TokenCounts {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  tool_call_count: number;
+}
+
+/** "12,345 in · 1,000 cached · 678 out · 2 tools"; zero parts dropped; a dash when nothing was metered. */
+const formatUsageTokens = (counts: TokenCounts): string => {
+  const parts = [
+    [counts.input_tokens, "in"],
+    [counts.cached_input_tokens, "cached"],
+    [counts.output_tokens, "out"],
+    [counts.tool_call_count, "tools"],
+  ] as const;
+  const shown = parts.filter(([n]) => n > 0).map(([n, label]) => `${n.toLocaleString("en-US")} ${label}`);
+  return shown.length ? shown.join(" · ") : "-";
+};
+
+export default formatUsageTokens;

--- a/lib/usage/isForbiddenError.ts
+++ b/lib/usage/isForbiddenError.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether a failed usage fetch was a 403, i.e. the account exists but the
+ * signed-in user may not read it.
+ */
+const isForbiddenError = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && (error as { status?: number }).status === 403;
+
+export default isForbiddenError;


### PR DESCRIPTION
Implements the /usage page row of recoupable/app#2000 (section 5, step 3).

## What

A customer can see a balance in the user menu but not what consumed it. This adds `/usage`: the account's charge line items from `GET /api/accounts/{id}/usage` (contract in the docs PR; api PR: https://github.com/recoupable/api/pull/864), newest first, with the period and its total.

- **Table**: when, what ran (`source · agent_type`), model (`provider / model_id`, or a dash for fixed-price charges), tokens (`1,200 in · 300 out · 2 tools`, dash when nothing was metered), cost. Cost is the API's `usd` string; the micro-dollar integer is typed but never rendered, which the tests assert.
- **Period summary**: `Aug 1, 2026 to Aug 27, 2026` and `Total $0.03` from `total_usd`.
- **Load more** while `next_cursor` is set (`useInfiniteQuery`, 20 per page).
- **States**: skeleton while loading, `No charges this period yet.`, and `You do not have access to this account's usage.` when the api answers 403 (the fetcher attaches the status to the error; `isForbiddenError` reads it).
- **Sidebar**: the balance row in the user menu (`CreditsUsage`) is now a link to `/usage` (kept the row rather than adding a menu item: the number is the thing people click to ask "where did it go").

Hook follows the composed-hooks rule: `useAccountUsage` pulls the account from `UserProvider` and the token from Privy, takes no params, and mirrors `useCredits`.

## Files

`app/usage/page.tsx`, `components/UsagePage/{UsagePage,UsagePageHeader,UsagePeriodSummary,UsageTable,UsageRow,UsageEmptyState,UsageNoAccess,UsageSkeleton,UsageLoadMore}.tsx`, `hooks/useAccountUsage.ts`, `lib/recoup/getAccountUsage.ts`, `lib/usage/{describeUsageEvent,describeUsageModel,formatUsageTokens,formatUsageDate,isForbiddenError}.ts`, `components/Sidebar/UserProfileDropdown/CreditsUsage.tsx`. One export per file, largest 54 lines.

## Tests

RED first (8 files failing), then GREEN: `UsagePage` (rows with USD and no integer, period total, empty, 403, skeleton, Load more calls `fetchNextPage`, all pages in one list), `useAccountUsage` (real `QueryClient`; first call without cursor, second with `next_cursor`, `hasNextPage` flips), `getAccountUsage` (URL with `limit`/`cursor`, bearer header, 403 carries status), the four helpers, and `CreditsUsage` (link href). `tsc` and `eslint` clean on the touched files.

## Sequencing

After the api endpoint PR (find it with `gh pr list --repo recoupable/api --search usage`). The preview only shows data once that api is deployed to `test` (app previews read `test-recoup-api`) or via the `recoup_api_override` sessionStorage hatch pointed at the api PR's preview URL. Screenshots in the preview-verification comment below.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/usage` page so customers who see a balance in the sidebar can see what consumed it, and links the sidebar balance to it. The page lists the account's charge line items from `GET /api/accounts/{id}/usage`, newest first, with the period total; it requires that API endpoint to be deployed first.

**New Features**
- Shows when, what ran, model, tokens, and cost per charge; costs come from the API's `usd` string, never the micro-dollar integer.
- Handles loading with a skeleton, an empty message when nothing was charged, a no-access message on 403, and a Load more button while a next cursor exists.
- Collapses Model and Tokens below `md` so Cost stays visible on phones.

<sup>Written for commit 5d889ad984fbd2c8ed05dbe3164c58f7dd4029dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Usage page showing account charges, dates, events, models, token counts, and costs.
  * Added period totals, loading placeholders, empty states, access messaging, and error handling.
  * Added pagination with a “Load more” option for additional usage records.
  * Linked the displayed account balance to the Usage page.
  * Optimized the usage table for mobile screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->