### PR TITLE
fix(tasks): center the task page, run page and tasks tabs at 2xl on desktop (app#2016 item 3)

### DIFF
--- a/components/TasksPage/PageContainer.tsx
+++ b/components/TasksPage/PageContainer.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * The centered content column for the task pages (`/tasks`, `/tasks/{id}`,
+ * `/runs/{runId}`): 2xl wide, centered, with horizontal padding, so desktop
+ * content has equal margins instead of sitting against the left edge
+ * (app#2016 item 3). One component so the next page cannot drift.
+ */
+export default function PageContainer({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn("mx-auto w-full max-w-2xl px-6", className)}>
+      {children}
+    </div>
+  );
+}

--- a/components/TasksPage/Run/RunPage.tsx
+++ b/components/TasksPage/Run/RunPage.tsx
@@ -3,6 +3,7 @@
 import { XCircle } from "lucide-react";
 import { useTaskRunStatus } from "@/hooks/useTaskRunStatus";
 import RunBreadcrumb from "./RunBreadcrumb";
+import PageContainer from "@/components/TasksPage/PageContainer";
 import RunPageSkeleton from "./RunPageSkeleton";
 import RunDetails from "./RunDetails";
 
@@ -31,9 +32,9 @@ export default function RunPage({ runId }: RunPageProps) {
   }
 
   return (
-    <div className="h-screen max-w-2xl">
+    <PageContainer className="h-screen">
       <RunBreadcrumb runId={runId} />
       {content}
-    </div>
+    </PageContainer>
   );
 }

--- a/components/TasksPage/Task/TaskPage.tsx
+++ b/components/TasksPage/Task/TaskPage.tsx
@@ -4,6 +4,7 @@ import { XCircle } from "lucide-react";
 import { useTask } from "@/hooks/useTask";
 import RunPageSkeleton from "@/components/TasksPage/Run/RunPageSkeleton";
 import TaskBreadcrumb from "./TaskBreadcrumb";
+import PageContainer from "@/components/TasksPage/PageContainer";
 import TaskPageHeader from "./TaskPageHeader";
 import TaskEditor from "./TaskEditor";
 
@@ -18,16 +19,16 @@ export default function TaskPage({ taskId }: { taskId: string }) {
 
   if (isLoading) {
     return (
-      <div className="h-screen max-w-2xl">
+      <PageContainer className="h-screen">
         <TaskBreadcrumb title="…" />
         <RunPageSkeleton />
-      </div>
+      </PageContainer>
     );
   }
 
   if (error || !task) {
     return (
-      <div className="h-screen max-w-2xl">
+      <PageContainer className="h-screen">
         <TaskBreadcrumb title="Not found" />
         <div className="flex flex-col items-center justify-center p-6">
           <XCircle className="size-8 text-muted-foreground" />
@@ -37,17 +38,17 @@ export default function TaskPage({ taskId }: { taskId: string }) {
               : "No task with this id on your account."}
           </p>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="h-screen max-w-2xl">
+    <PageContainer className="h-screen">
       <TaskBreadcrumb title={task.title} />
-      <div className="mx-auto flex flex-col gap-4 p-6">
+      <div className="flex flex-col gap-4 py-6">
         <TaskPageHeader task={task} />
         <TaskEditor key={task.updated_at ?? task.id} task={task} />
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/components/TasksPage/Task/__tests__/TaskPage.test.tsx
+++ b/components/TasksPage/Task/__tests__/TaskPage.test.tsx
@@ -52,4 +52,12 @@ describe("TaskPage (chat#2006 item 8)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(push).toHaveBeenCalledWith("/tasks");
   });
+
+  it("renders inside the shared centered container (app#2016 item 3)", () => {
+    const { container } = render(<TaskPage taskId="task-a" />);
+    const root = container.firstElementChild as HTMLElement;
+    for (const cls of ["mx-auto", "w-full", "max-w-2xl", "px-6"]) {
+      expect(root.className).toContain(cls);
+    }
+  });
 });

--- a/components/TasksPage/TasksPage.tsx
+++ b/components/TasksPage/TasksPage.tsx
@@ -6,7 +6,7 @@ import { TasksPageHeader } from "./TasksPageHeader";
 
 const TasksPage = () => {
   return (
-    <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
+    <div className="grow py-8">
       <PageContainer>
         <TasksPageHeader />
         <TasksTabs />

--- a/components/TasksPage/TasksPage.tsx
+++ b/components/TasksPage/TasksPage.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import TasksTabs from "./TasksTabs";
+import PageContainer from "./PageContainer";
 import { TasksPageHeader } from "./TasksPageHeader";
 
 const TasksPage = () => {
   return (
     <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
-      <TasksPageHeader />
-      <TasksTabs />
+      <PageContainer>
+        <TasksPageHeader />
+        <TasksTabs />
+      </PageContainer>
     </div>
   );
 };

--- a/components/TasksPage/TasksTabs.tsx
+++ b/components/TasksPage/TasksTabs.tsx
@@ -31,7 +31,7 @@ const TasksTabs = () => {
   const runs = taskRuns ?? [];
 
   return (
-    <Tabs defaultValue={defaultTab} className="max-w-2xl">
+    <Tabs defaultValue={defaultTab} className="w-full">
       <TabsList>
         <TabsTrigger value="schedules">Schedules</TabsTrigger>
         <TabsTrigger value="recents">Recents</TabsTrigger>

--- a/components/TasksPage/__tests__/PageContainer.test.tsx
+++ b/components/TasksPage/__tests__/PageContainer.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PageContainer from "@/components/TasksPage/PageContainer";
+
+describe("PageContainer", () => {
+  it("centers its content at the 2xl width with horizontal padding (app#2016 item 3)", () => {
+    render(
+      <PageContainer>
+        <p>body</p>
+      </PageContainer>,
+    );
+    const el = screen.getByText("body").parentElement as HTMLElement;
+    for (const cls of ["mx-auto", "w-full", "max-w-2xl", "px-6"]) {
+      expect(el.className).toContain(cls);
+    }
+  });
+
+  it("merges extra classes so a page can keep its own height rule", () => {
+    render(
+      <PageContainer className="h-screen">
+        <p>body</p>
+      </PageContainer>,
+    );
+    const el = screen.getByText("body").parentElement as HTMLElement;
+    expect(el.className).toContain("h-screen");
+    expect(el.className).toContain("mx-auto");
+  });
+});

--- a/components/TasksPage/__tests__/TasksPage.test.tsx
+++ b/components/TasksPage/__tests__/TasksPage.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import TasksPage from "@/components/TasksPage/TasksPage";
+
+vi.mock("@/components/TasksPage/TasksTabs", () => ({
+  default: () => <div>tabs</div>,
+}));
+vi.mock("@/components/TasksPage/TasksPageHeader", () => ({
+  TasksPageHeader: () => <div>header</div>,
+}));
+
+describe("TasksPage", () => {
+  it("lets PageContainer own the width and padding so the list is centered in the full panel (app#2016 item 3)", () => {
+    render(<TasksPage />);
+    const container = screen.getByText("tabs").parentElement as HTMLElement;
+    expect(container.className).toContain("max-w-2xl");
+    const wrapper = container.parentElement as HTMLElement;
+    expect(wrapper.className).not.toMatch(/max-w-\[/);
+    expect(wrapper.className).not.toMatch(/\bpx-/);
+  });
+});


### PR DESCRIPTION
Item 3 of [app#2016](https://github.com/recoupable/app/issues/2016). Owner's call was **center**: `max-w-2xl mx-auto w-full px-6`.

## What changes
- New `components/TasksPage/PageContainer.tsx` — the one centered content column (`mx-auto w-full max-w-2xl px-6`, merges a `className`).
- `TaskPage` (loading, not-found and loaded states) and `RunPage` use it in place of the left-justified `h-screen max-w-2xl` wrappers; the loaded task body drops its own `mx-auto` and uses `py-6`.
- `TasksPage` wraps the header and tabs in it; `TasksTabs` drops its `max-w-2xl` in favour of `w-full`.
- `TasksPage`'s outer wrapper drops its legacy `md:max-w-[calc(100vw-200px)]` cap and `px-6 md:px-12` (`0bf0154`). At 1440px that cap held the page to 1240px inside a 1368px panel, so the centered column sat 64px left of the panel's center with a 128px dead gutter on the right; the padding also stacked with the container's `px-6` on mobile (rows got 294px instead of 342px). `PageContainer` now owns width and padding.

## Tests
RED → GREEN: `PageContainer` (classes, className merge), `TaskPage` (root carries the container classes) and `TasksPage` (wrapper carries no width cap or horizontal padding). `components/TasksPage`: 10 passing; eslint + prettier + tsc clean on the touched files.

## Verification
Preview screenshots at 1440px and 390px of `/tasks`, `/tasks/{id}` and `/runs/{runId}` in a comment below, with measured left/right margins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PS8hmiwR1rGD6c41n6gD8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the tasks list, task detail, and run pages at a 2xl width on desktop so content no longer sits against the left edge and has equal margins.

- Introduces a shared `PageContainer` for the centered column, used across loading, error, and loaded states.
- Drops the tasks list wrapper's legacy width cap and padding so the column centers in the full panel instead of sitting off-center.
- Keeps existing height rules via merged classes; the wrapper swap also fixes double padding on mobile.

<sup>Written for commit 0bf015412941f51594693368542e2a2dcb9f676e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


