### PR TITLE
fix(tasks): gate the task and run page skeletons on isPending so the not-found copy cannot flash (app#2016 item 4)

### DIFF
--- a/components/TasksPage/Run/RunPage.tsx
+++ b/components/TasksPage/Run/RunPage.tsx
@@ -12,13 +12,13 @@ interface RunPageProps {
 }
 
 export default function RunPage({ runId }: RunPageProps) {
-  const { data, isLoading, error } = useTaskRunStatus(runId);
+  const { data, isPending, error } = useTaskRunStatus(runId);
 
   let content;
 
-  if (isLoading || !data) {
+  if (isPending) {
     content = <RunPageSkeleton />;
-  } else if (error) {
+  } else if (error || !data) {
     content = (
       <div className="flex flex-col items-center justify-center p-4">
         <XCircle className="size-8 text-red-500" />

--- a/components/TasksPage/Run/__tests__/RunPage.test.tsx
+++ b/components/TasksPage/Run/__tests__/RunPage.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RunPage from "@/components/TasksPage/Run/RunPage";
+
+const runQuery: {
+  data: { status: string } | undefined;
+  isPending: boolean;
+  isLoading: boolean;
+  error: Error | null;
+} = { data: undefined, isPending: true, isLoading: false, error: null };
+vi.mock("@/hooks/useTaskRunStatus", () => ({
+  useTaskRunStatus: () => runQuery,
+}));
+vi.mock("@/components/TasksPage/Run/RunBreadcrumb", () => ({
+  default: () => <nav>crumb</nav>,
+}));
+vi.mock("@/components/TasksPage/Run/RunPageSkeleton", () => ({
+  default: () => <div data-testid="skeleton" />,
+}));
+vi.mock("@/components/TasksPage/Run/RunDetails", () => ({
+  default: ({ data }: { data: { status: string } }) => <p>{data.status}</p>,
+}));
+
+describe("RunPage", () => {
+  beforeEach(() => {
+    Object.assign(runQuery, {
+      data: undefined,
+      isPending: true,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("shows the skeleton while the query is pending but not yet fetching (app#2016 item 4)", () => {
+    render(<RunPage runId="run-a" />);
+    expect(screen.getByTestId("skeleton")).toBeTruthy();
+  });
+
+  it("shows the error once the query fails instead of staying on the skeleton", () => {
+    Object.assign(runQuery, { isPending: false, error: new Error("HTTP 404") });
+    render(<RunPage runId="run-a" />);
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+    expect(screen.getByText("HTTP 404")).toBeTruthy();
+  });
+
+  it("renders the run once data arrives", () => {
+    Object.assign(runQuery, {
+      isPending: false,
+      data: { status: "COMPLETED" },
+    });
+    render(<RunPage runId="run-a" />);
+    expect(screen.getByText("COMPLETED")).toBeTruthy();
+  });
+});

--- a/components/TasksPage/Task/TaskPage.tsx
+++ b/components/TasksPage/Task/TaskPage.tsx
@@ -15,9 +15,12 @@ import TaskEditor from "./TaskEditor";
  * history from Trigger.dev, each recent run linking to its run page.
  */
 export default function TaskPage({ taskId }: { taskId: string }) {
-  const { data: task, isLoading, error } = useTask(taskId);
+  const { data: task, isPending, error } = useTask(taskId);
 
-  if (isLoading) {
+  // isPending covers both the window where the query is disabled waiting
+  // for Privy auth and the fetch itself; isLoading is false in the first
+  // window, so gating on it would show the not-found copy (app#2016 item 4).
+  if (isPending) {
     return (
       <PageContainer className="h-screen">
         <TaskBreadcrumb title="…" />

--- a/components/TasksPage/Task/__tests__/TaskPage.test.tsx
+++ b/components/TasksPage/Task/__tests__/TaskPage.test.tsx
@@ -1,27 +1,28 @@
 // @vitest-environment jsdom
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import TaskPage from "@/components/TasksPage/Task/TaskPage";
 
 const push = vi.fn();
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
 
-vi.mock("@/hooks/useTask", () => ({
-  useTask: () => ({
-    data: {
-      id: "task-a",
-      title: "Weekly report",
-      prompt: "Do the thing",
-      schedule: "0 9 * * *",
-      model: "anthropic/claude-sonnet-5",
-      timezone: "UTC",
-      enabled: true,
-    },
-    isLoading: false,
-    error: null,
-  }),
-}));
+const loadedTask = {
+  id: "task-a",
+  title: "Weekly report",
+  prompt: "Do the thing",
+  schedule: "0 9 * * *",
+  model: "anthropic/claude-sonnet-5",
+  timezone: "UTC",
+  enabled: true,
+};
+const taskQuery: {
+  data: typeof loadedTask | null | undefined;
+  isPending: boolean;
+  isLoading: boolean;
+  error: Error | null;
+} = { data: loadedTask, isPending: false, isLoading: false, error: null };
+vi.mock("@/hooks/useTask", () => ({ useTask: () => taskQuery }));
 
 vi.mock("@/components/TasksPage/Task/TaskBreadcrumb", () => ({
   default: ({ title }: { title: string }) => <nav>{title}</nav>,
@@ -40,6 +41,15 @@ vi.mock("@/components/TasksPage/Task/TaskActions", () => ({
 }));
 
 describe("TaskPage (chat#2006 item 8)", () => {
+  beforeEach(() => {
+    Object.assign(taskQuery, {
+      data: loadedTask,
+      isPending: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
   it("renders the editable details with the task's current values", () => {
     render(<TaskPage taskId="task-a" />);
     expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
@@ -59,5 +69,28 @@ describe("TaskPage (chat#2006 item 8)", () => {
     for (const cls of ["mx-auto", "w-full", "max-w-2xl", "px-6"]) {
       expect(root.className).toContain(cls);
     }
+  });
+
+  it("shows the skeleton, not the not-found copy, while the query is pending but not yet fetching (app#2016 item 4)", () => {
+    Object.assign(taskQuery, {
+      data: undefined,
+      isPending: true,
+      isLoading: false,
+    });
+    render(<TaskPage taskId="task-a" />);
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByText("…")).toBeTruthy();
+  });
+
+  it("shows the not-found copy once the query resolves with no task", () => {
+    Object.assign(taskQuery, {
+      data: null,
+      isPending: false,
+      isLoading: false,
+    });
+    render(<TaskPage taskId="task-a" />);
+    expect(screen.getByRole("status").textContent).toBe(
+      "No task with this id on your account.",
+    );
   });
 });


### PR DESCRIPTION
Item 4 of [app#2016](https://github.com/recoupable/app/issues/2016). On a hard load of `/tasks/{id}` the page showed "No task with this id on your account." first, then the skeleton, then the task.

## Why
`useTask` (and `useTaskRunStatus`) are `enabled: !!id && authenticated`. Until Privy restores the session the query is disabled, and TanStack Query v5 reports a disabled, never-fetched query as `status: "pending"` with `isLoading` (`isPending && isFetching`) **false** and `data` undefined. `TaskPage` checked `isLoading` first, then `error || !task`, so the auth-wait window rendered the not-found branch.

## What changes
- `TaskPage`: the skeleton is gated on `isPending`, which is true through both the auth wait and the fetch; the not-found copy only renders after the query resolves to `null` or throws.
- `RunPage`: same guard, replacing `isLoading || !data`. Side effect: its error branch is now reachable (before, a failed query left `data` undefined and stayed on the skeleton).

## Tests
RED → GREEN: `TaskPage` (pending + not fetching → skeleton, no `role="status"` copy; resolved `null` → not-found copy) and a new `RunPage` test (pending → skeleton; error → message; data → details). `components/TasksPage`: 15 passing; eslint, prettier and tsc clean on the touched files.

## Verification
Preview: hard load of a real task id sampled every 100ms from navigation until the task renders; documented-vs-actual table with the sequence of states in a comment below, alongside the same probe on prod (which reproduces the flash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PS8hmiwR1rGD6c41n6gD8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the "No task with this id on your account." copy from flashing before the skeleton on hard loads of `/tasks/{id}` and run pages. The query stays disabled until Privy restores the session, and TanStack Query v5 reports a disabled, never-fetched query as pending but not loading, so the old `isLoading` guard fell through to the not-found branch during the auth wait.

Both `TaskPage` and `RunPage` now gate their skeletons on `isPending`, which stays true through the auth wait and the fetch. Side effect: `RunPage`'s error branch is now reachable instead of leaving the page on the skeleton after a failed query.

<sup>Written for commit c2c102a301f9f922560bfd06fd7c52d407716628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

