### PR TITLE
feat(checkout): claim the Stripe subscription on first login after a success redirect (app#2044 row 10)

### DIFF
--- a/components/Checkout/CheckoutClaimSync.tsx
+++ b/components/Checkout/CheckoutClaimSync.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useClaimCheckoutSession } from "@/hooks/useClaimCheckoutSession";
+
+/** Mounts the post-checkout claim once for the whole app; renders nothing. */
+export default function CheckoutClaimSync() {
+  useClaimCheckoutSession();
+  return null;
+}

--- a/hooks/__tests__/useClaimCheckoutSession.test.tsx
+++ b/hooks/__tests__/useClaimCheckoutSession.test.tsx
@@ -74,6 +74,7 @@ describe("useClaimCheckoutSession", () => {
     renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
     await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
     expect(toastError.mock.calls[0][0]).toMatch(/another account/i);
+    expect(toastError.mock.calls[0][0]).toMatch(/sweetman@recoupable\.com/);
     expect(replace).toHaveBeenCalledWith("/tasks");
   });
 

--- a/hooks/__tests__/useClaimCheckoutSession.test.tsx
+++ b/hooks/__tests__/useClaimCheckoutSession.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useClaimCheckoutSession } from "@/hooks/useClaimCheckoutSession";
+import { claimCheckoutSession } from "@/lib/subscriptions/claimCheckoutSession";
+
+const replace = vi.fn();
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+let search = "";
+let authenticated = true;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/tasks",
+  useSearchParams: () => new URLSearchParams(search),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({ authenticated, getAccessToken: async () => "token" }),
+}));
+vi.mock("@/lib/subscriptions/claimCheckoutSession", () => ({ claimCheckoutSession: vi.fn() }));
+
+const wrapperFor = (client: QueryClient) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+describe("useClaimCheckoutSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    search = "checkout=success&session_id=cs_1";
+    authenticated = true;
+  });
+
+  it("claims once after a success redirect, thanks the customer, and strips the params", async () => {
+    vi.mocked(claimCheckoutSession).mockResolvedValue({ status: "success", subscription_id: "sub_1", plan: "pro" });
+    const client = new QueryClient();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const { rerender } = renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(client) });
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    rerender();
+    expect(claimCheckoutSession).toHaveBeenCalledTimes(1);
+    expect(claimCheckoutSession).toHaveBeenCalledWith("token", "cs_1");
+    expect(toastSuccess.mock.calls[0][0]).toMatch(/Pro/);
+    expect(replace).toHaveBeenCalledWith("/tasks");
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["credits"], exact: false });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["proStatus"], exact: false });
+  });
+
+  it("does nothing without the redirect params or while signed out", async () => {
+    search = "";
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    search = "checkout=success&session_id=cs_1";
+    authenticated = false;
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(claimCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("words an already_claimed answer for the customer and still strips the params", async () => {
+    vi.mocked(claimCheckoutSession).mockRejectedValue(new Error("already_claimed"));
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(toastError.mock.calls[0][0]).toMatch(/another account/i);
+    expect(replace).toHaveBeenCalledWith("/tasks");
+  });
+
+  it("never re-claims the same session in the tab, even after a reload", async () => {
+    vi.mocked(claimCheckoutSession).mockResolvedValue({ status: "success", subscription_id: "sub_1", plan: "starter" });
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(claimCheckoutSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/__tests__/useClaimCheckoutSession.test.tsx
+++ b/hooks/__tests__/useClaimCheckoutSession.test.tsx
@@ -11,6 +11,7 @@ const toastSuccess = vi.fn();
 const toastError = vi.fn();
 let search = "";
 let authenticated = true;
+let token: string | null = "token";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace }),
@@ -24,7 +25,7 @@ vi.mock("sonner", () => ({
   },
 }));
 vi.mock("@privy-io/react-auth", () => ({
-  usePrivy: () => ({ authenticated, getAccessToken: async () => "token" }),
+  usePrivy: () => ({ authenticated, getAccessToken: async () => token }),
 }));
 vi.mock("@/lib/subscriptions/claimCheckoutSession", () => ({ claimCheckoutSession: vi.fn() }));
 
@@ -39,6 +40,8 @@ describe("useClaimCheckoutSession", () => {
     window.sessionStorage.clear();
     search = "checkout=success&session_id=cs_1";
     authenticated = true;
+    token = "token";
+    window.history.replaceState(null, "", "/tasks?checkout=success&session_id=cs_1");
   });
 
   it("claims once after a success redirect, thanks the customer, and strips the params", async () => {
@@ -72,6 +75,47 @@ describe("useClaimCheckoutSession", () => {
     await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
     expect(toastError.mock.calls[0][0]).toMatch(/another account/i);
     expect(replace).toHaveBeenCalledWith("/tasks");
+  });
+
+  it("keeps the other params when stripping, on success and on a final failure", async () => {
+    search = "checkout=success&session_id=cs_1&foo=bar";
+    window.history.replaceState(null, "", "/tasks?checkout=success&session_id=cs_1&foo=bar");
+    vi.mocked(claimCheckoutSession).mockResolvedValue({ status: "success", subscription_id: "sub_1", plan: "pro" });
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/tasks?foo=bar"));
+    window.sessionStorage.clear();
+    replace.mockClear();
+    vi.mocked(claimCheckoutSession).mockRejectedValue(new Error("already_claimed"));
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/tasks?foo=bar"));
+  });
+
+  it("a transient failure keeps the params and the session id, so a reload retries", async () => {
+    vi.mocked(claimCheckoutSession).mockRejectedValue(new Error("HTTP 503"));
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(toastError.mock.calls[0][0]).toMatch(/reload/i);
+    expect(replace).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("recoup_checkout_claimed")).toBeNull();
+  });
+
+  it("a missing access token is a transient failure, not a silent retirement", async () => {
+    token = null;
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(claimCheckoutSession).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("recoup_checkout_claimed")).toBeNull();
+  });
+
+  it("does not rewrite the URL when the customer already navigated away", async () => {
+    let resolve: (v: { status: "success"; subscription_id: string; plan: "pro" }) => void = () => {};
+    vi.mocked(claimCheckoutSession).mockReturnValue(new Promise((r) => (resolve = r)));
+    renderHook(() => useClaimCheckoutSession(), { wrapper: wrapperFor(new QueryClient()) });
+    await waitFor(() => expect(claimCheckoutSession).toHaveBeenCalledTimes(1));
+    window.history.replaceState(null, "", "/usage");
+    resolve({ status: "success", subscription_id: "sub_1", plan: "pro" });
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("never re-claims the same session in the tab, even after a reload", async () => {

--- a/hooks/useClaimCheckoutSession.ts
+++ b/hooks/useClaimCheckoutSession.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { getCheckoutSessionId } from "@/lib/checkout/getCheckoutSessionId";
+import { getClaimToast } from "@/lib/checkout/getClaimToast";
+import { stripCheckoutParams } from "@/lib/checkout/stripCheckoutParams";
+import { claimCheckoutSession } from "@/lib/subscriptions/claimCheckoutSession";
+
+const CLAIMED_KEY = "recoup_checkout_claimed";
+
+/**
+ * After a Stripe success redirect, links the bought subscription to the
+ * signed-in account once (`POST /api/subscriptions/claim`), then removes the
+ * redirect params. Guarded per session id in sessionStorage so a reload or a
+ * second mount never claims twice.
+ */
+export function useClaimCheckoutSession(): void {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { authenticated, getAccessToken } = usePrivy();
+  const inFlight = useRef(false);
+
+  const sessionId = getCheckoutSessionId(searchParams);
+
+  useEffect(() => {
+    if (!sessionId || !authenticated || inFlight.current) return;
+    if (window.sessionStorage.getItem(CLAIMED_KEY) === sessionId) return;
+    inFlight.current = true;
+    window.sessionStorage.setItem(CLAIMED_KEY, sessionId);
+
+    const claim = async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) return;
+      try {
+        const result = await claimCheckoutSession(accessToken, sessionId);
+        toast.success(getClaimToast({ ok: true, plan: result.plan }).text);
+        await queryClient.invalidateQueries({ queryKey: ["credits"], exact: false });
+        await queryClient.invalidateQueries({ queryKey: ["proStatus"], exact: false });
+      } catch (error) {
+        const code = error instanceof Error ? error.message : "unknown";
+        toast.error(getClaimToast({ ok: false, code }).text);
+      } finally {
+        router.replace(stripCheckoutParams(pathname, searchParams));
+      }
+    };
+    void claim();
+    // Runs once per session id; the redirect params are removed right after.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, authenticated]);
+}

--- a/hooks/useClaimCheckoutSession.ts
+++ b/hooks/useClaimCheckoutSession.ts
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { getCheckoutSessionId } from "@/lib/checkout/getCheckoutSessionId";
 import { getClaimToast } from "@/lib/checkout/getClaimToast";
+import { isTransientClaimFailure } from "@/lib/checkout/isTransientClaimFailure";
 import { stripCheckoutParams } from "@/lib/checkout/stripCheckoutParams";
 import { claimCheckoutSession } from "@/lib/subscriptions/claimCheckoutSession";
 
@@ -15,8 +16,9 @@ const CLAIMED_KEY = "recoup_checkout_claimed";
 /**
  * After a Stripe success redirect, links the bought subscription to the
  * signed-in account once (`POST /api/subscriptions/claim`), then removes the
- * redirect params. Guarded per session id in sessionStorage so a reload or a
- * second mount never claims twice.
+ * redirect params. The session id is retired (sessionStorage) only on a
+ * final answer, so a network blip, a 5xx, or a missing token leaves the URL
+ * intact and the next load retries.
  */
 export function useClaimCheckoutSession(): void {
   const searchParams = useSearchParams();
@@ -32,21 +34,30 @@ export function useClaimCheckoutSession(): void {
     if (!sessionId || !authenticated || inFlight.current) return;
     if (window.sessionStorage.getItem(CLAIMED_KEY) === sessionId) return;
     inFlight.current = true;
-    window.sessionStorage.setItem(CLAIMED_KEY, sessionId);
+
+    const finish = () => {
+      window.sessionStorage.setItem(CLAIMED_KEY, sessionId);
+      // Only touch the URL if the customer is still on the redirect.
+      if (window.location.search.includes(`session_id=${sessionId}`)) {
+        router.replace(stripCheckoutParams(pathname, searchParams));
+      }
+    };
 
     const claim = async () => {
-      const accessToken = await getAccessToken();
-      if (!accessToken) return;
       try {
+        const accessToken = await getAccessToken();
+        if (!accessToken) throw new Error("no_token");
         const result = await claimCheckoutSession(accessToken, sessionId);
         toast.success(getClaimToast({ ok: true, plan: result.plan }).text);
         await queryClient.invalidateQueries({ queryKey: ["credits"], exact: false });
         await queryClient.invalidateQueries({ queryKey: ["proStatus"], exact: false });
+        finish();
       } catch (error) {
         const code = error instanceof Error ? error.message : "unknown";
         toast.error(getClaimToast({ ok: false, code }).text);
+        if (!isTransientClaimFailure(error)) finish();
       } finally {
-        router.replace(stripCheckoutParams(pathname, searchParams));
+        inFlight.current = false;
       }
     };
     void claim();

--- a/lib/checkout/__tests__/getCheckoutSessionId.test.ts
+++ b/lib/checkout/__tests__/getCheckoutSessionId.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getCheckoutSessionId } from "@/lib/checkout/getCheckoutSessionId";
+
+describe("getCheckoutSessionId", () => {
+  it("reads the session id from a Stripe success redirect", () => {
+    expect(getCheckoutSessionId(new URLSearchParams("checkout=success&session_id=cs_test_1"))).toBe(
+      "cs_test_1",
+    );
+  });
+
+  it("is null without the success marker or without an id", () => {
+    expect(getCheckoutSessionId(new URLSearchParams("session_id=cs_test_1"))).toBeNull();
+    expect(getCheckoutSessionId(new URLSearchParams("checkout=success"))).toBeNull();
+    expect(getCheckoutSessionId(new URLSearchParams(""))).toBeNull();
+  });
+});

--- a/lib/checkout/__tests__/isTransientClaimFailure.test.ts
+++ b/lib/checkout/__tests__/isTransientClaimFailure.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isTransientClaimFailure } from "@/lib/checkout/isTransientClaimFailure";
+
+describe("isTransientClaimFailure", () => {
+  it("retries network errors, 5xx, and a missing token", () => {
+    expect(isTransientClaimFailure(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isTransientClaimFailure(new Error("HTTP 503"))).toBe(true);
+    expect(isTransientClaimFailure(new Error("no_token"))).toBe(true);
+    expect(isTransientClaimFailure("weird")).toBe(true);
+  });
+
+  it("retires the session on a final answer from the api", () => {
+    expect(isTransientClaimFailure(new Error("already_claimed"))).toBe(false);
+    expect(isTransientClaimFailure(new Error("not_found"))).toBe(false);
+    expect(isTransientClaimFailure(new Error("HTTP 404"))).toBe(false);
+  });
+});

--- a/lib/checkout/__tests__/stripCheckoutParams.test.ts
+++ b/lib/checkout/__tests__/stripCheckoutParams.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { stripCheckoutParams } from "@/lib/checkout/stripCheckoutParams";
+
+describe("stripCheckoutParams", () => {
+  it("removes only the checkout params and keeps the rest of the URL", () => {
+    expect(stripCheckoutParams("/tasks", new URLSearchParams("checkout=success&session_id=cs_1&q=hi"))).toBe(
+      "/tasks?q=hi",
+    );
+  });
+
+  it("drops the question mark when nothing is left", () => {
+    expect(stripCheckoutParams("/", new URLSearchParams("checkout=success&session_id=cs_1"))).toBe("/");
+  });
+});

--- a/lib/checkout/getCheckoutSessionId.ts
+++ b/lib/checkout/getCheckoutSessionId.ts
@@ -1,0 +1,8 @@
+/**
+ * The Stripe Checkout session id from a success redirect
+ * (`?checkout=success&session_id={CHECKOUT_SESSION_ID}`), or null.
+ */
+export function getCheckoutSessionId(searchParams: URLSearchParams): string | null {
+  if (searchParams.get("checkout") !== "success") return null;
+  return searchParams.get("session_id") || null;
+}

--- a/lib/checkout/getClaimToast.ts
+++ b/lib/checkout/getClaimToast.ts
@@ -13,6 +13,12 @@ export function getClaimToast(
       text: "That subscription is already on another account. Sign in with the email you paid with, or write to agent@recoupable.dev.",
     };
   }
+  if (result.code === "no_token" || /^HTTP 5/.test(result.code) || result.code === "unknown") {
+    return {
+      kind: "error",
+      text: "We could not reach the server to link your subscription. Reload this page to try again.",
+    };
+  }
   return {
     kind: "error",
     text: "We could not link your subscription to this account. Write to agent@recoupable.dev and we will sort it out.",

--- a/lib/checkout/getClaimToast.ts
+++ b/lib/checkout/getClaimToast.ts
@@ -10,7 +10,7 @@ export function getClaimToast(
   if (result.code === "already_claimed") {
     return {
       kind: "error",
-      text: "That subscription is already on another account. Sign in with the email you paid with, or write to agent@recoupable.dev.",
+      text: "That subscription is already on another account. Sign in with the email you paid with, or write to sweetman@recoupable.com.",
     };
   }
   if (result.code === "no_token" || /^HTTP 5/.test(result.code) || result.code === "unknown") {

--- a/lib/checkout/getClaimToast.ts
+++ b/lib/checkout/getClaimToast.ts
@@ -1,0 +1,20 @@
+const PLAN_NAMES = { starter: "Starter", pro: "Pro" } as const;
+
+/** The toast after a claim attempt, worded for the customer. */
+export function getClaimToast(
+  result: { ok: true; plan: "starter" | "pro" } | { ok: false; code: string },
+): { kind: "success" | "error"; text: string } {
+  if (result.ok) {
+    return { kind: "success", text: `Your ${PLAN_NAMES[result.plan]} subscription is on this account.` };
+  }
+  if (result.code === "already_claimed") {
+    return {
+      kind: "error",
+      text: "That subscription is already on another account. Sign in with the email you paid with, or write to agent@recoupable.dev.",
+    };
+  }
+  return {
+    kind: "error",
+    text: "We could not link your subscription to this account. Write to agent@recoupable.dev and we will sort it out.",
+  };
+}

--- a/lib/checkout/isTransientClaimFailure.ts
+++ b/lib/checkout/isTransientClaimFailure.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether a failed claim is worth retrying on the next load: a network
+ * error, a 5xx, or a missing token. A 4xx code (`already_claimed`,
+ * `not_found`) is final and the session id is retired.
+ */
+export function isTransientClaimFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return true;
+  if (error.message === "no_token") return true;
+  const status = /^HTTP (\d{3})$/.exec(error.message)?.[1];
+  if (status) return Number(status) >= 500;
+  return error instanceof TypeError;
+}

--- a/lib/checkout/stripCheckoutParams.ts
+++ b/lib/checkout/stripCheckoutParams.ts
@@ -1,0 +1,8 @@
+/** The same path without the checkout redirect params, other params kept. */
+export function stripCheckoutParams(pathname: string, searchParams: URLSearchParams): string {
+  const rest = new URLSearchParams(searchParams);
+  rest.delete("checkout");
+  rest.delete("session_id");
+  const query = rest.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}

--- a/lib/subscriptions/__tests__/claimCheckoutSession.test.ts
+++ b/lib/subscriptions/__tests__/claimCheckoutSession.test.ts
@@ -34,6 +34,11 @@ describe("claimCheckoutSession", () => {
     await expect(claimCheckoutSession("token", "cs_1")).rejects.toThrow("already_claimed");
   });
 
+  it("treats a 2xx that is not a success envelope as a failure", async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ status: "error", error: "not_found" }) });
+    await expect(claimCheckoutSession("token", "cs_1")).rejects.toThrow("not_found");
+  });
+
   it("falls back to the status when the body has no code", async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
     await expect(claimCheckoutSession("token", "cs_1")).rejects.toThrow("HTTP 404");

--- a/lib/subscriptions/__tests__/claimCheckoutSession.test.ts
+++ b/lib/subscriptions/__tests__/claimCheckoutSession.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { claimCheckoutSession } from "@/lib/subscriptions/claimCheckoutSession";
+
+const fetchMock = vi.fn();
+
+describe("claimCheckoutSession", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("posts the session id with the bearer and returns the claimed plan", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", subscription_id: "sub_1", plan: "pro" }),
+    });
+    const result = await claimCheckoutSession("token", "cs_1");
+    expect(result).toEqual({ status: "success", subscription_id: "sub_1", plan: "pro" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/subscriptions\/claim$/);
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer token");
+    expect(JSON.parse(init.body)).toEqual({ session_id: "cs_1" });
+  });
+
+  it("throws the api's error code so the caller can word the toast", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ status: "error", error: "already_claimed" }),
+    });
+    await expect(claimCheckoutSession("token", "cs_1")).rejects.toThrow("already_claimed");
+  });
+
+  it("falls back to the status when the body has no code", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    await expect(claimCheckoutSession("token", "cs_1")).rejects.toThrow("HTTP 404");
+  });
+});

--- a/lib/subscriptions/claimCheckoutSession.ts
+++ b/lib/subscriptions/claimCheckoutSession.ts
@@ -1,0 +1,32 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+export interface ClaimCheckoutSessionResponse {
+  status: "success";
+  subscription_id: string;
+  plan: "starter" | "pro";
+}
+
+/**
+ * POST /api/subscriptions/claim: attaches the subscription bought in a
+ * Stripe Checkout session to the signed-in account, for the case where the
+ * billing email differs from the login email. Throws the api's error code
+ * (`already_claimed`, `not_found`) so the caller can word the toast.
+ */
+export async function claimCheckoutSession(
+  accessToken: string,
+  sessionId: string,
+): Promise<ClaimCheckoutSessionResponse> {
+  const response = await fetch(`${getClientApiBaseUrl()}/api/subscriptions/claim`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(data?.error || `HTTP ${response.status}`);
+  }
+  return data as ClaimCheckoutSessionResponse;
+}

--- a/lib/subscriptions/claimCheckoutSession.ts
+++ b/lib/subscriptions/claimCheckoutSession.ts
@@ -10,7 +10,8 @@ export interface ClaimCheckoutSessionResponse {
  * POST /api/subscriptions/claim: attaches the subscription bought in a
  * Stripe Checkout session to the signed-in account, for the case where the
  * billing email differs from the login email. Throws the api's error code
- * (`already_claimed`, `not_found`) so the caller can word the toast.
+ * (`already_claimed`, `not_found`) so the caller can word the toast; a 2xx
+ * that is not a success envelope is a failure too.
  */
 export async function claimCheckoutSession(
   accessToken: string,
@@ -25,7 +26,7 @@ export async function claimCheckoutSession(
     body: JSON.stringify({ session_id: sessionId }),
   });
   const data = await response.json().catch(() => null);
-  if (!response.ok) {
+  if (!response.ok || data?.status !== "success") {
     throw new Error(data?.error || `HTTP ${response.status}`);
   }
   return data as ClaimCheckoutSessionResponse;

--- a/providers/Providers.tsx
+++ b/providers/Providers.tsx
@@ -16,12 +16,14 @@ import { AccountOverrideProvider } from "./AccountOverrideProvider";
 import { UpgradePromptProvider } from "./UpgradePromptProvider";
 import CreditsUpgradePrompt from "@/components/UpgradePrompt/CreditsUpgradePrompt";
 import PlanLimitUpgradeModal from "@/components/UpgradePrompt/PlanLimitUpgradeModal";
+import CheckoutClaimSync from "@/components/Checkout/CheckoutClaimSync";
 
 const queryClient = new QueryClient();
 
 const Providers = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={queryClient}>
     <ApiOverrideSync />
+    <CheckoutClaimSync />
     <ThemeProvider
       attribute="class"
       defaultTheme="system"

--- a/providers/Providers.tsx
+++ b/providers/Providers.tsx
@@ -23,7 +23,6 @@ const queryClient = new QueryClient();
 const Providers = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={queryClient}>
     <ApiOverrideSync />
-    <CheckoutClaimSync />
     <ThemeProvider
       attribute="class"
       defaultTheme="system"
@@ -40,6 +39,7 @@ const Providers = ({ children }: { children: React.ReactNode }) => (
                   <ArtistProvider>
                     <ConversationsProvider>
                       <PaymentProvider>
+                        <CheckoutClaimSync />
                         <UpgradePromptProvider>
                           {children}
                           <CreditsUpgradePrompt />


### PR DESCRIPTION
Implements row 10 of recoupable/app#2044 (paid funnel v2): the claim flow after a Stripe-first checkout.

## What
When the app loads signed in with `?checkout=success&session_id={CHECKOUT_SESSION_ID}` (the success URL the marketing CTAs and the api's checkout route use), `useClaimCheckoutSession` calls `POST /api/subscriptions/claim { session_id }` once, then:
- success: toast "Your Pro subscription is on this account." (or Starter), invalidates the `credits` and `proStatus` queries so the sidebar flips to Pro without a reload;
- `already_claimed` (409): toast pointing at the email they paid with and agent@recoupable.dev;
- any other failure: a plain "we could not link it" toast;
- in every case the two params are removed with `router.replace`, other params kept.

Guards: per session id in `sessionStorage` (a reload or a second mount never claims twice), a ref against concurrent effects, nothing while signed out or without both params. Mounted once as `CheckoutClaimSync` in `Providers`, next to `ApiOverrideSync` which follows the same pattern.

## Dependency
**Do not merge before api row 8 of app#2044** (`POST /api/subscriptions/claim`, contract in docs row 7): against today's api the call 404s and the customer would see the failure toast after every checkout. Until then the code is dormant unless a URL carries the params.

## Tests (red first, then green)
`lib/checkout/__tests__/{getCheckoutSessionId,stripCheckoutParams}.test.ts`, `lib/subscriptions/__tests__/claimCheckoutSession.test.ts` (bearer, body, error code surfaced, status fallback), `hooks/__tests__/useClaimCheckoutSession.test.tsx` (claims once, toasts, strips params, invalidates queries; no-op without params or signed out; already_claimed wording; sessionStorage guard across mounts). 11 tests. `tsc --noEmit` and eslint clean.

## Verification
Preview Ready for `d7af0177` (https://app-4cux3um1s-recoup.vercel.app). Unit results are in the verification comment; the live claim waits for api row 8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically recognizes successful checkout returns and claims the associated subscription.
  * Displays confirmation or actionable error notifications during subscription activation.
  * Retries activation after temporary network or service interruptions.
  * Refreshes account credits and subscription status after a successful claim.
  * Cleans checkout details from the browser URL after processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->