### PR TITLE
feat(projects): client project status pages at /projects/{projectId} (app#2048)

### DIFF
--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from "next/navigation";
+import ProjectPage from "@/components/ProjectPage/ProjectPage";
+import { isProjectId } from "@/lib/projects/isProjectId";
+
+interface PageProps {
+  params: Promise<{ projectId: string }>;
+}
+
+/**
+ * A client project's status (app#2048). A non-UUID segment is a not-found here
+ * rather than a request the API has to answer.
+ */
+export default async function Page({ params }: PageProps) {
+  const { projectId } = await params;
+  if (!isProjectId(projectId)) notFound();
+
+  return <ProjectPage projectId={projectId} />;
+}

--- a/app/projects/[projectId]/tasks/[taskId]/page.tsx
+++ b/app/projects/[projectId]/tasks/[taskId]/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation";
+import ProjectTaskPage from "@/components/ProjectPage/Task/ProjectTaskPage";
+import { isProjectId } from "@/lib/projects/isProjectId";
+
+interface PageProps {
+  params: Promise<{ projectId: string; taskId: string }>;
+}
+
+/** One task on a client project (app#2048). */
+export default async function Page({ params }: PageProps) {
+  const { projectId, taskId } = await params;
+  if (!isProjectId(projectId) || !isProjectId(taskId)) notFound();
+
+  return <ProjectTaskPage projectId={projectId} taskId={taskId} />;
+}

--- a/components/ProjectPage/NeedsYouCard.tsx
+++ b/components/ProjectPage/NeedsYouCard.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import NeedsYouPill from "./NeedsYouPill";
+import ProjectTaskMeta from "./ProjectTaskMeta";
+import type { ProjectTask } from "@/lib/projects/types";
+
+/**
+ * A task waiting on the viewer, pinned above the list as a card.
+ *
+ * The card treatment, not the pill alone, is what separates it: a client opens
+ * this link to find out what is being asked of them, and a plain row in sort
+ * order can be scrolled past.
+ */
+const NeedsYouCard = ({ task }: { task: ProjectTask }) => (
+  <Link
+    href={`/projects/${task.project_id}/tasks/${task.id}`}
+    className="flex flex-col gap-2 rounded-lg bg-card p-4 shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.04)] transition-shadow hover:shadow-[0px_0px_0px_1px_var(--border),0px_4px_8px_rgba(0,0,0,0.06)]"
+  >
+    <div className="flex items-start gap-3">
+      <div className="flex grow flex-col gap-1.5">
+        <span className="text-base font-medium text-foreground">{task.title}</span>
+        {task.description && (
+          <span className="text-sm leading-relaxed text-muted-foreground">
+            {task.description}
+          </span>
+        )}
+      </div>
+      <NeedsYouPill />
+    </div>
+    <ProjectTaskMeta task={task} />
+  </Link>
+);
+
+export default NeedsYouCard;

--- a/components/ProjectPage/NeedsYouPill.tsx
+++ b/components/ProjectPage/NeedsYouPill.tsx
@@ -1,0 +1,16 @@
+import { AlertCircle } from "lucide-react";
+
+/**
+ * Marks the one thing on a project waiting on the person reading it.
+ *
+ * The only colour on an otherwise achromatic page, which is what makes the ask
+ * unmissable. `DESIGN.md` allows colour for status and forbids it in chrome.
+ */
+const NeedsYouPill = () => (
+  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+    <AlertCircle className="size-3.5" />
+    Needs you
+  </span>
+);
+
+export default NeedsYouPill;

--- a/components/ProjectPage/NeedsYouPill.tsx
+++ b/components/ProjectPage/NeedsYouPill.tsx
@@ -1,4 +1,5 @@
 import { AlertCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 
 /**
  * Marks the one thing on a project waiting on the person reading it.
@@ -7,10 +8,13 @@ import { AlertCircle } from "lucide-react";
  * unmissable. `DESIGN.md` allows colour for status and forbids it in chrome.
  */
 const NeedsYouPill = () => (
-  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+  <Badge
+    variant="outline"
+    className="shrink-0 gap-1 rounded-full border-transparent bg-amber-500/10 py-1 font-medium text-amber-700 dark:text-amber-400"
+  >
     <AlertCircle className="size-3.5" />
     Needs you
-  </span>
+  </Badge>
 );
 
 export default NeedsYouPill;

--- a/components/ProjectPage/ProjectNotFound.tsx
+++ b/components/ProjectPage/ProjectNotFound.tsx
@@ -1,0 +1,19 @@
+import { XCircle } from "lucide-react";
+
+/**
+ * What a signed-in account sees for a project it cannot reach.
+ *
+ * The API answers 404 for both an unknown id and a caller who is not a
+ * collaborator, and this copy keeps that ambiguity: telling someone a project
+ * exists but is not theirs is how a project id gets confirmed.
+ */
+const ProjectNotFound = ({ message }: { message: string }) => (
+  <div className="flex flex-col items-center justify-center p-6">
+    <XCircle className="size-8 text-muted-foreground" />
+    <p className="mt-3 text-sm text-muted-foreground" role="status">
+      {message}
+    </p>
+  </div>
+);
+
+export default ProjectNotFound;

--- a/components/ProjectPage/ProjectPage.tsx
+++ b/components/ProjectPage/ProjectPage.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useMemo } from "react";
+import PageContainer from "@/components/TasksPage/PageContainer";
+import RunPageSkeleton from "@/components/TasksPage/Run/RunPageSkeleton";
+import { useProject } from "@/hooks/useProject";
+import { useUserProvider } from "@/providers/UserProvder";
+import { splitProjectTasks } from "@/lib/projects/splitProjectTasks";
+import ProjectProgress from "./ProjectProgress";
+import ProjectTasksTabs from "./ProjectTasksTabs";
+import ProjectNotFound from "./ProjectNotFound";
+
+/**
+ * `/projects/{projectId}`: what a client sees of the work we are doing for
+ * them (app#2048). Active items first with their own pinned above, completed
+ * below.
+ */
+export default function ProjectPage({ projectId }: { projectId: string }) {
+  const { data, isPending, error } = useProject(projectId);
+  const { userData } = useUserProvider();
+  const viewerAccountId = userData?.account_id ?? null;
+
+  const tasks = useMemo(
+    () => splitProjectTasks(data?.tasks ?? [], viewerAccountId),
+    [data?.tasks, viewerAccountId],
+  );
+
+  // isPending covers the window where the query waits on Privy auth as well as
+  // the fetch, so the not-found copy cannot flash before either has run
+  // (the same trap app#2016 item 4 fixed on the task page).
+  if (isPending) {
+    return (
+      <PageContainer className="h-screen">
+        <RunPageSkeleton />
+      </PageContainer>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <PageContainer className="h-screen">
+        <ProjectNotFound
+          message={
+            error instanceof Error
+              ? error.message
+              : "No project with this id on your account."
+          }
+        />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <div className="grow py-8">
+      <PageContainer className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2.5">
+          <h1 className="font-heading text-3xl font-bold tracking-tight">
+            {data.project.name}
+          </h1>
+          <p className="font-sans text-lg font-light text-muted-foreground">
+            Live status of the work Recoupable is doing for you. Comment on any
+            task to reach us.
+          </p>
+        </div>
+
+        <ProjectProgress
+          done={tasks.completed.length}
+          total={data.tasks.length}
+          needsYou={tasks.needsYou.length}
+        />
+
+        <ProjectTasksTabs tasks={tasks} />
+      </PageContainer>
+    </div>
+  );
+}

--- a/components/ProjectPage/ProjectProgress.tsx
+++ b/components/ProjectPage/ProjectProgress.tsx
@@ -1,3 +1,5 @@
+import { Progress } from "@/components/ui/progress";
+
 /** How far along the engagement is, in one line the client reads first. */
 const ProjectProgress = ({
   done,
@@ -9,19 +11,19 @@ const ProjectProgress = ({
   needsYou: number;
 }) => (
   <div className="flex flex-col gap-2">
-    <div className="h-1 overflow-hidden rounded-full bg-muted">
-      <div
-        className="h-full bg-foreground transition-[width] duration-300"
-        style={{ width: total ? `${(done / total) * 100}%` : "0%" }}
-      />
-    </div>
+    <Progress
+      value={total ? (done / total) * 100 : 0}
+      className="h-1 bg-muted"
+      aria-label={`${done} of ${total} tasks done`}
+    />
     <div className="flex items-center gap-3 text-xs text-muted-foreground">
       <span>
         {done} of {total} done
       </span>
       {needsYou > 0 && (
         <span>
-          {needsYou} task{needsYou === 1 ? "" : "s"} need{needsYou === 1 ? "s" : ""} you
+          {needsYou} task{needsYou === 1 ? "" : "s"} need
+          {needsYou === 1 ? "s" : ""} you
         </span>
       )}
     </div>

--- a/components/ProjectPage/ProjectProgress.tsx
+++ b/components/ProjectPage/ProjectProgress.tsx
@@ -1,0 +1,31 @@
+/** How far along the engagement is, in one line the client reads first. */
+const ProjectProgress = ({
+  done,
+  total,
+  needsYou,
+}: {
+  done: number;
+  total: number;
+  needsYou: number;
+}) => (
+  <div className="flex flex-col gap-2">
+    <div className="h-1 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full bg-foreground transition-[width] duration-300"
+        style={{ width: total ? `${(done / total) * 100}%` : "0%" }}
+      />
+    </div>
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <span>
+        {done} of {total} done
+      </span>
+      {needsYou > 0 && (
+        <span>
+          {needsYou} task{needsYou === 1 ? "" : "s"} need{needsYou === 1 ? "s" : ""} you
+        </span>
+      )}
+    </div>
+  </div>
+);
+
+export default ProjectProgress;

--- a/components/ProjectPage/ProjectProgress.tsx
+++ b/components/ProjectPage/ProjectProgress.tsx
@@ -12,7 +12,7 @@ const ProjectProgress = ({
 }) => (
   <div className="flex flex-col gap-2">
     <Progress
-      value={total ? (done / total) * 100 : 0}
+      value={total ? Math.round((done / total) * 100) : 0}
       className="h-1 bg-muted"
       aria-label={`${done} of ${total} tasks done`}
     />

--- a/components/ProjectPage/ProjectTaskMeta.tsx
+++ b/components/ProjectPage/ProjectTaskMeta.tsx
@@ -1,0 +1,29 @@
+import { Calendar, MessageSquare } from "lucide-react";
+import { formatTaskDate } from "@/lib/projects/formatTaskDate";
+import type { ProjectTask } from "@/lib/projects/types";
+
+/** Due or completed date, plus the comment count when there is one. */
+const ProjectTaskMeta = ({ task }: { task: ProjectTask }) => {
+  const completed = formatTaskDate(task.completed_at);
+  const due = formatTaskDate(task.due_date);
+  const date = completed ? `Completed ${completed}` : due ? `Due ${due}` : null;
+
+  return (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      {date && (
+        <span className="inline-flex items-center gap-1.5">
+          <Calendar className="size-3.5" />
+          {date}
+        </span>
+      )}
+      {!!task.comment_count && (
+        <span className="inline-flex items-center gap-1.5">
+          <MessageSquare className="size-3.5" />
+          {task.comment_count}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default ProjectTaskMeta;

--- a/components/ProjectPage/ProjectTaskRow.tsx
+++ b/components/ProjectPage/ProjectTaskRow.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import ProjectTaskMeta from "./ProjectTaskMeta";
+import type { ProjectTask } from "@/lib/projects/types";
+
+/** One task in the list. Everything not waiting on the viewer renders like this. */
+const ProjectTaskRow = ({ task }: { task: ProjectTask }) => (
+  <Link
+    href={`/projects/${task.project_id}/tasks/${task.id}`}
+    className="flex items-start gap-4 border-b border-border py-4 transition-colors hover:bg-muted/50"
+  >
+    <div className="flex grow flex-col gap-1.5">
+      <span className="text-base font-medium text-foreground">{task.title}</span>
+      {task.description && (
+        <span className="text-sm leading-relaxed text-muted-foreground">
+          {task.description}
+        </span>
+      )}
+      <ProjectTaskMeta task={task} />
+    </div>
+    <ChevronRight className="mt-1 size-4 shrink-0 text-muted-foreground" />
+  </Link>
+);
+
+export default ProjectTaskRow;

--- a/components/ProjectPage/ProjectTasksTabs.tsx
+++ b/components/ProjectPage/ProjectTasksTabs.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import NeedsYouCard from "./NeedsYouCard";
+import ProjectTaskRow from "./ProjectTaskRow";
+import type { SplitTasks } from "@/lib/projects/splitProjectTasks";
+
+/** Active and Completed, with the viewer's own items pinned above Active. */
+const ProjectTasksTabs = ({ tasks }: { tasks: SplitTasks }) => (
+  <Tabs defaultValue="active" className="w-full">
+    <TabsList>
+      <TabsTrigger value="active">Active</TabsTrigger>
+      <TabsTrigger value="completed">Completed</TabsTrigger>
+    </TabsList>
+
+    <TabsContent value="active" className="mt-4 flex flex-col gap-1">
+      {tasks.needsYou.map((task) => (
+        <NeedsYouCard key={task.id} task={task} />
+      ))}
+      {tasks.active.map((task) => (
+        <ProjectTaskRow key={task.id} task={task} />
+      ))}
+      {!tasks.needsYou.length && !tasks.active.length && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Nothing active right now.
+        </p>
+      )}
+    </TabsContent>
+
+    <TabsContent value="completed" className="mt-4 flex flex-col">
+      {tasks.completed.map((task) => (
+        <ProjectTaskRow key={task.id} task={task} />
+      ))}
+      {!tasks.completed.length && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Nothing completed yet.
+        </p>
+      )}
+    </TabsContent>
+  </Tabs>
+);
+
+export default ProjectTasksTabs;

--- a/components/ProjectPage/Task/ProjectCollaboratorList.tsx
+++ b/components/ProjectPage/Task/ProjectCollaboratorList.tsx
@@ -1,0 +1,21 @@
+import type { ProjectCollaborator } from "@/lib/projects/types";
+
+/** Everyone with access to the project. Names come from the account. */
+const ProjectCollaboratorList = ({
+  collaborators,
+}: {
+  collaborators: ProjectCollaborator[];
+}) => (
+  <div className="flex flex-col gap-2.5">
+    {collaborators.map((person) => (
+      <div key={person.account_id} className="flex items-center gap-2.5">
+        <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-[11px] font-medium text-muted-foreground">
+          {person.name?.trim()?.[0]?.toUpperCase() ?? "·"}
+        </span>
+        <span className="text-sm">{person.name?.trim() || "Someone"}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export default ProjectCollaboratorList;

--- a/components/ProjectPage/Task/ProjectCollaboratorList.tsx
+++ b/components/ProjectPage/Task/ProjectCollaboratorList.tsx
@@ -1,3 +1,5 @@
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { nameInitial } from "@/lib/projects/nameInitial";
 import type { ProjectCollaborator } from "@/lib/projects/types";
 
 /** Everyone with access to the project. Names come from the account. */
@@ -9,9 +11,11 @@ const ProjectCollaboratorList = ({
   <div className="flex flex-col gap-2.5">
     {collaborators.map((person) => (
       <div key={person.account_id} className="flex items-center gap-2.5">
-        <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-[11px] font-medium text-muted-foreground">
-          {person.name?.trim()?.[0]?.toUpperCase() ?? "·"}
-        </span>
+        <Avatar className="size-6">
+          <AvatarFallback className="text-[11px] font-medium text-muted-foreground">
+            {nameInitial(person.name)}
+          </AvatarFallback>
+        </Avatar>
         <span className="text-sm">{person.name?.trim() || "Someone"}</span>
       </div>
     ))}

--- a/components/ProjectPage/Task/ProjectCommentComposer.tsx
+++ b/components/ProjectPage/Task/ProjectCommentComposer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateProjectComment } from "@/hooks/useCreateProjectComment";
+import { COMMENT_MAX_LENGTH } from "@/lib/projects/createProjectComment";
+
+/** Post a comment. Append-only: there is no edit and no delete. */
+const ProjectCommentComposer = ({
+  projectId,
+  taskId,
+}: {
+  projectId: string;
+  taskId: string;
+}) => {
+  const [body, setBody] = useState("");
+  const { mutate, isPending } = useCreateProjectComment(projectId, taskId);
+  const canPost = body.trim().length > 0 && !isPending;
+
+  const post = () => {
+    if (!canPost) return;
+    mutate(body.trim(), { onSuccess: () => setBody("") });
+  };
+
+  return (
+    <div className="flex flex-col gap-2.5 rounded-lg p-3.5 shadow-[0px_0px_0px_1px_var(--border)]">
+      <Textarea
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        maxLength={COMMENT_MAX_LENGTH}
+        placeholder="Write a comment"
+        className="min-h-[64px] resize-y border-0 p-0 shadow-none focus-visible:ring-0"
+      />
+      <div className="flex justify-end">
+        <Button size="sm" onClick={post} disabled={!canPost}>
+          {isPending ? "Posting…" : "Post"}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCommentComposer;

--- a/components/ProjectPage/Task/ProjectCommentList.tsx
+++ b/components/ProjectPage/Task/ProjectCommentList.tsx
@@ -1,9 +1,7 @@
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { formatTaskDate } from "@/lib/projects/formatTaskDate";
+import { nameInitial } from "@/lib/projects/nameInitial";
 import type { ProjectComment } from "@/lib/projects/types";
-
-/** Author initial for the avatar. Falls back to a dot rather than a stray letter. */
-const initial = (comment: ProjectComment) =>
-  comment.author_name?.trim()?.[0]?.toUpperCase() ?? "·";
 
 /**
  * The comment feed, oldest first so it reads top to bottom.
@@ -28,9 +26,11 @@ const ProjectCommentList = ({ comments }: { comments: ProjectComment[] }) => {
           className="flex flex-col gap-1.5 rounded-lg p-3.5 shadow-[0px_0px_0px_1px_var(--border)]"
         >
           <div className="flex items-center gap-2">
-            <span className="inline-flex size-5.5 items-center justify-center rounded-full bg-muted text-[11px] font-medium text-muted-foreground">
-              {initial(comment)}
-            </span>
+            <Avatar className="size-6">
+              <AvatarFallback className="text-[11px] font-medium text-muted-foreground">
+                {nameInitial(comment.author_name)}
+              </AvatarFallback>
+            </Avatar>
             <span className="text-[13px] font-medium">
               {comment.author_name?.trim() || "Someone"}
             </span>

--- a/components/ProjectPage/Task/ProjectCommentList.tsx
+++ b/components/ProjectPage/Task/ProjectCommentList.tsx
@@ -1,0 +1,50 @@
+import { formatTaskDate } from "@/lib/projects/formatTaskDate";
+import type { ProjectComment } from "@/lib/projects/types";
+
+/** Author initial for the avatar. Falls back to a dot rather than a stray letter. */
+const initial = (comment: ProjectComment) =>
+  comment.author_name?.trim()?.[0]?.toUpperCase() ?? "·";
+
+/**
+ * The comment feed, oldest first so it reads top to bottom.
+ *
+ * `author_name` is null for most accounts today — nothing captures a name at
+ * sign-up — so the name falls back to "Someone" rather than rendering blank.
+ */
+const ProjectCommentList = ({ comments }: { comments: ProjectComment[] }) => {
+  if (!comments.length) {
+    return (
+      <p className="py-4 text-sm text-muted-foreground">
+        No comments yet. Anything you write here reaches us.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      {comments.map((comment) => (
+        <div
+          key={comment.id}
+          className="flex flex-col gap-1.5 rounded-lg p-3.5 shadow-[0px_0px_0px_1px_var(--border)]"
+        >
+          <div className="flex items-center gap-2">
+            <span className="inline-flex size-5.5 items-center justify-center rounded-full bg-muted text-[11px] font-medium text-muted-foreground">
+              {initial(comment)}
+            </span>
+            <span className="text-[13px] font-medium">
+              {comment.author_name?.trim() || "Someone"}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatTaskDate(comment.created_at)}
+            </span>
+          </div>
+          <p className="whitespace-pre-line text-sm leading-relaxed">
+            {comment.body}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ProjectCommentList;

--- a/components/ProjectPage/Task/ProjectTaskBreadcrumb.tsx
+++ b/components/ProjectPage/Task/ProjectTaskBreadcrumb.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from "@/components/ui/breadcrumb";
+
+const ProjectTaskBreadcrumb = ({
+  projectId,
+  projectName,
+  title,
+}: {
+  projectId: string;
+  projectName: string;
+  title: string;
+}) => (
+  <Breadcrumb className="pt-4">
+    <BreadcrumbList>
+      <BreadcrumbItem>
+        <BreadcrumbLink asChild>
+          <Link href={`/projects/${projectId}`}>{projectName}</Link>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage className="truncate">{title}</BreadcrumbPage>
+      </BreadcrumbItem>
+    </BreadcrumbList>
+  </Breadcrumb>
+);
+
+export default ProjectTaskBreadcrumb;

--- a/components/ProjectPage/Task/ProjectTaskCompletion.tsx
+++ b/components/ProjectPage/Task/ProjectTaskCompletion.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Check, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useSetProjectTaskComplete } from "@/hooks/useSetProjectTaskComplete";
+
+/**
+ * The completion control. Any collaborator may close or reopen any task,
+ * including the client — the API records who did it either way.
+ */
+const ProjectTaskCompletion = ({
+  projectId,
+  taskId,
+  isComplete,
+}: {
+  projectId: string;
+  taskId: string;
+  isComplete: boolean;
+}) => {
+  const { mutate, isPending } = useSetProjectTaskComplete(projectId, taskId);
+
+  if (isComplete) {
+    return (
+      <div className="flex items-center gap-4">
+        <span className="inline-flex items-center gap-2 text-sm font-medium">
+          <CheckCircle2 className="size-4.5 text-green-500" />
+          Completed
+        </span>
+        <button
+          type="button"
+          onClick={() => mutate(false)}
+          disabled={isPending}
+          className="text-sm text-muted-foreground underline underline-offset-4 disabled:opacity-50"
+        >
+          {isPending ? "Saving…" : "Mark incomplete"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <Button onClick={() => mutate(true)} disabled={isPending}>
+      <Check className="size-4" />
+      {isPending ? "Saving…" : "Mark complete"}
+    </Button>
+  );
+};
+
+export default ProjectTaskCompletion;

--- a/components/ProjectPage/Task/ProjectTaskHeader.tsx
+++ b/components/ProjectPage/Task/ProjectTaskHeader.tsx
@@ -1,0 +1,47 @@
+import { Calendar, CheckCircle2 } from "lucide-react";
+import NeedsYouPill from "../NeedsYouPill";
+import { formatTaskDate } from "@/lib/projects/formatTaskDate";
+import type { ProjectTask } from "@/lib/projects/types";
+
+/** Title, status, date and description for one task. */
+const ProjectTaskHeader = ({
+  task,
+  isComplete,
+  needsYou,
+}: {
+  task: ProjectTask;
+  isComplete: boolean;
+  needsYou: boolean;
+}) => {
+  const completed = formatTaskDate(task.completed_at);
+  const due = formatTaskDate(task.due_date);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h1 className="font-heading text-2xl font-bold tracking-tight">
+        {task.title}
+      </h1>
+      <div className="flex flex-wrap items-center gap-3">
+        {isComplete ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-green-500/10 px-2.5 py-1 text-xs font-medium text-green-600 dark:text-green-400">
+            <CheckCircle2 className="size-3.5" />
+            Completed
+          </span>
+        ) : (
+          needsYou && <NeedsYouPill />
+        )}
+        {(completed || due) && (
+          <span className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground">
+            <Calendar className="size-3.5" />
+            {completed ? `Completed ${completed}` : `Due ${due}`}
+          </span>
+        )}
+      </div>
+      {task.description && (
+        <p className="text-[15px] leading-relaxed">{task.description}</p>
+      )}
+    </div>
+  );
+};
+
+export default ProjectTaskHeader;

--- a/components/ProjectPage/Task/ProjectTaskPage.tsx
+++ b/components/ProjectPage/Task/ProjectTaskPage.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import PageContainer from "@/components/TasksPage/PageContainer";
+import RunPageSkeleton from "@/components/TasksPage/Run/RunPageSkeleton";
+import { useProject } from "@/hooks/useProject";
+import { useProjectTask } from "@/hooks/useProjectTask";
+import { useUserProvider } from "@/providers/UserProvder";
+import { getTaskState } from "@/lib/projects/getTaskState";
+import ProjectNotFound from "../ProjectNotFound";
+import ProjectTaskBreadcrumb from "./ProjectTaskBreadcrumb";
+import ProjectTaskHeader from "./ProjectTaskHeader";
+import ProjectTaskCompletion from "./ProjectTaskCompletion";
+import ProjectTaskTabs from "./ProjectTaskTabs";
+
+/**
+ * `/projects/{projectId}/tasks/{taskId}` (app#2048): one task, its completion
+ * control, and the thread against it.
+ */
+export default function ProjectTaskPage({
+  projectId,
+  taskId,
+}: {
+  projectId: string;
+  taskId: string;
+}) {
+  const { data, isPending, error } = useProjectTask(projectId, taskId);
+  // Only for the breadcrumb label; the task read is what gates the page.
+  const { data: project } = useProject(projectId);
+  const { userData } = useUserProvider();
+
+  if (isPending) {
+    return (
+      <PageContainer className="h-screen">
+        <RunPageSkeleton />
+      </PageContainer>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <PageContainer className="h-screen">
+        <ProjectNotFound
+          message={
+            error instanceof Error
+              ? error.message
+              : "No task with this id on your account."
+          }
+        />
+      </PageContainer>
+    );
+  }
+
+  const { isComplete, needsYou } = getTaskState(
+    data.task,
+    userData?.account_id ?? null,
+  );
+
+  return (
+    <div className="grow pb-8">
+      <PageContainer className="flex flex-col gap-5">
+        <ProjectTaskBreadcrumb
+          projectId={projectId}
+          projectName={project?.project.name ?? "Project"}
+          title={data.task.title}
+        />
+        <ProjectTaskHeader
+          task={data.task}
+          isComplete={isComplete}
+          needsYou={needsYou}
+        />
+        <div className="border-y border-border py-4">
+          <ProjectTaskCompletion
+            projectId={projectId}
+            taskId={data.task.id}
+            isComplete={isComplete}
+          />
+        </div>
+        <ProjectTaskTabs projectId={projectId} data={data} />
+      </PageContainer>
+    </div>
+  );
+}

--- a/components/ProjectPage/Task/ProjectTaskTabs.tsx
+++ b/components/ProjectPage/Task/ProjectTaskTabs.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import ProjectCommentList from "./ProjectCommentList";
+import ProjectCommentComposer from "./ProjectCommentComposer";
+import ProjectCollaboratorList from "./ProjectCollaboratorList";
+import type { ProjectTaskResponse } from "@/lib/projects/types";
+
+/**
+ * Messages / Documents / Collaborators.
+ *
+ * Documents renders an empty state: the table, storage and download URLs it
+ * needs are a separate piece of work, and the tab is here so the shape is
+ * visible rather than appearing later out of nowhere.
+ */
+const ProjectTaskTabs = ({
+  projectId,
+  data,
+}: {
+  projectId: string;
+  data: ProjectTaskResponse;
+}) => (
+  <Tabs defaultValue="messages" className="w-full">
+    <TabsList>
+      <TabsTrigger value="messages">Messages</TabsTrigger>
+      <TabsTrigger value="documents">Documents</TabsTrigger>
+      <TabsTrigger value="collaborators">Collaborators</TabsTrigger>
+    </TabsList>
+
+    <TabsContent value="messages" className="mt-4 flex flex-col gap-4">
+      <ProjectCommentList comments={data.comments} />
+      <ProjectCommentComposer projectId={projectId} taskId={data.task.id} />
+    </TabsContent>
+
+    <TabsContent value="documents" className="mt-4">
+      <p className="py-4 text-sm text-muted-foreground">
+        No documents on this task yet.
+      </p>
+    </TabsContent>
+
+    <TabsContent value="collaborators" className="mt-4">
+      <ProjectCollaboratorList collaborators={data.collaborators} />
+    </TabsContent>
+  </Tabs>
+);
+
+export default ProjectTaskTabs;

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -11,6 +11,7 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
+    value={value}
     className={cn(
       "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
       className

--- a/hooks/useCreateProjectComment.ts
+++ b/hooks/useCreateProjectComment.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { createProjectComment } from "@/lib/projects/createProjectComment";
+
+/**
+ * Post a comment on a task (app#2048). Comments are append-only, so a
+ * successful post only ever adds to the feed.
+ */
+export function useCreateProjectComment(projectId: string, taskId: string) {
+  const { getAccessToken } = usePrivy();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (body: string) => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Please sign in to comment");
+      return createProjectComment(accessToken, projectId, taskId, body);
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["project", projectId, "task", taskId],
+      }),
+  });
+}

--- a/hooks/useProject.ts
+++ b/hooks/useProject.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { getProject } from "@/lib/projects/getProject";
+import type { ProjectResponse } from "@/lib/projects/types";
+
+/**
+ * One client project with its tasks (app#2048). Resolves to null when the API
+ * answers 404 — an unknown id, or one the signed-in account cannot reach.
+ */
+export function useProject(projectId: string) {
+  const { getAccessToken, authenticated } = usePrivy();
+
+  return useQuery<ProjectResponse | null>({
+    queryKey: ["project", projectId],
+    queryFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Please sign in to view this project");
+      return getProject(accessToken, projectId);
+    },
+    enabled: !!projectId && authenticated,
+  });
+}

--- a/hooks/useProjectTask.ts
+++ b/hooks/useProjectTask.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { getProjectTask } from "@/lib/projects/getProjectTask";
+import type { ProjectTaskResponse } from "@/lib/projects/types";
+
+/**
+ * One project task with its comment feed (app#2048). Null on 404, as
+ * `useProject`. Keyed under the project so a task mutation can invalidate the
+ * project list alongside it.
+ */
+export function useProjectTask(projectId: string, taskId: string) {
+  const { getAccessToken, authenticated } = usePrivy();
+
+  return useQuery<ProjectTaskResponse | null>({
+    queryKey: ["project", projectId, "task", taskId],
+    queryFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Please sign in to view this task");
+      return getProjectTask(accessToken, projectId, taskId);
+    },
+    enabled: !!projectId && !!taskId && authenticated,
+  });
+}

--- a/hooks/useSetProjectTaskComplete.ts
+++ b/hooks/useSetProjectTaskComplete.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { setProjectTaskComplete } from "@/lib/projects/setProjectTaskComplete";
+
+/**
+ * Toggle a task's completion (app#2048). Invalidates the whole project key so
+ * the task page and the list it came from agree without a reload.
+ */
+export function useSetProjectTaskComplete(projectId: string, taskId: string) {
+  const { getAccessToken } = usePrivy();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (completed: boolean) => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Please sign in to update this task");
+      return setProjectTaskComplete(accessToken, projectId, taskId, completed);
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["project", projectId] }),
+  });
+}

--- a/lib/projects/__tests__/formatTaskDate.test.ts
+++ b/lib/projects/__tests__/formatTaskDate.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { formatTaskDate } from "@/lib/projects/formatTaskDate";
+
+describe("formatTaskDate", () => {
+  it("renders a due date as a calendar day, with no timezone shift", () => {
+    // A bare date must not be parsed as UTC midnight and rendered as the day
+    // before in a negative-offset timezone.
+    expect(formatTaskDate("2026-09-12")).toBe("Sep 12");
+  });
+
+  it("renders a completion timestamp as a calendar day", () => {
+    expect(formatTaskDate("2026-08-31T18:04:00Z")).toBe("Aug 31");
+  });
+
+  it("returns null when there is no date", () => {
+    expect(formatTaskDate(null)).toBeNull();
+  });
+});

--- a/lib/projects/__tests__/getTaskState.test.ts
+++ b/lib/projects/__tests__/getTaskState.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { getTaskState } from "@/lib/projects/getTaskState";
+import type { ProjectTask } from "@/lib/projects/types";
+
+const task = (over: Partial<ProjectTask> = {}): ProjectTask => ({
+  id: "t1",
+  project_id: "p1",
+  title: "Distribution portal access",
+  description: null,
+  due_date: null,
+  assignee_account_id: null,
+  completed_at: null,
+  completed_by: null,
+  created_at: "2026-08-31T00:00:00Z",
+  ...over,
+});
+
+describe("getTaskState", () => {
+  it("is completed once completed_at is set, whoever it is assigned to", () => {
+    const state = getTaskState(task({ completed_at: "2026-08-31T00:00:00Z", assignee_account_id: "me" }), "me");
+    expect(state.isComplete).toBe(true);
+    expect(state.needsYou).toBe(false);
+  });
+
+  it("needs you when an open task is assigned to the viewer", () => {
+    expect(getTaskState(task({ assignee_account_id: "me" }), "me").needsYou).toBe(true);
+  });
+
+  it("does not need you when the task is assigned to someone else", () => {
+    expect(getTaskState(task({ assignee_account_id: "them" }), "me").needsYou).toBe(false);
+  });
+
+  it("does not need you when nobody is assigned, or nobody is signed in", () => {
+    expect(getTaskState(task(), "me").needsYou).toBe(false);
+    expect(getTaskState(task({ assignee_account_id: "me" }), null).needsYou).toBe(false);
+  });
+});

--- a/lib/projects/__tests__/isProjectId.test.ts
+++ b/lib/projects/__tests__/isProjectId.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { isProjectId } from "@/lib/projects/isProjectId";
+
+describe("isProjectId", () => {
+  it("accepts a UUID in either case", () => {
+    expect(isProjectId("5e9eca42-b5af-47ef-83c9-3e498506a3d6")).toBe(true);
+    expect(isProjectId("5E9ECA42-B5AF-47EF-83C9-3E498506A3D6")).toBe(true);
+  });
+
+  it("rejects anything that is not a bare UUID", () => {
+    expect(isProjectId("not-a-uuid")).toBe(false);
+    expect(isProjectId("5e9eca42-b5af-47ef-83c9-3e498506a3d6/tasks")).toBe(false);
+    expect(isProjectId("")).toBe(false);
+  });
+});

--- a/lib/projects/__tests__/splitProjectTasks.test.ts
+++ b/lib/projects/__tests__/splitProjectTasks.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { splitProjectTasks } from "@/lib/projects/splitProjectTasks";
+import type { ProjectTask } from "@/lib/projects/types";
+
+const task = (id: string, over: Partial<ProjectTask> = {}): ProjectTask => ({
+  id,
+  project_id: "p1",
+  title: id,
+  created_at: "2026-08-31T00:00:00Z",
+  ...over,
+});
+
+describe("splitProjectTasks", () => {
+  it("pins the viewer's open tasks, keeps the rest in order, and sets completed aside", () => {
+    const split = splitProjectTasks(
+      [
+        task("ours"),
+        task("yours", { assignee_account_id: "me" }),
+        task("done", { completed_at: "2026-08-31T00:00:00Z" }),
+        task("later"),
+      ],
+      "me",
+    );
+
+    expect(split.needsYou.map((t) => t.id)).toEqual(["yours"]);
+    expect(split.active.map((t) => t.id)).toEqual(["ours", "later"]);
+    expect(split.completed.map((t) => t.id)).toEqual(["done"]);
+  });
+
+  it("never pins a completed task, even one assigned to the viewer", () => {
+    const split = splitProjectTasks(
+      [task("done", { assignee_account_id: "me", completed_at: "2026-08-31T00:00:00Z" })],
+      "me",
+    );
+    expect(split.needsYou).toEqual([]);
+    expect(split.completed.map((t) => t.id)).toEqual(["done"]);
+  });
+
+  it("pins nothing when nobody is signed in", () => {
+    const split = splitProjectTasks([task("yours", { assignee_account_id: "me" })], null);
+    expect(split.needsYou).toEqual([]);
+    expect(split.active.map((t) => t.id)).toEqual(["yours"]);
+  });
+});

--- a/lib/projects/createProjectComment.ts
+++ b/lib/projects/createProjectComment.ts
@@ -1,0 +1,35 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { ProjectComment } from "@/lib/projects/types";
+
+/** Longest comment the API accepts, per the documented contract. */
+export const COMMENT_MAX_LENGTH = 4000;
+
+/**
+ * Post a comment on a task, attributed to the signed-in account.
+ * @see https://docs.recoupable.dev/api-reference/projects/comments-create
+ */
+export async function createProjectComment(
+  accessToken: string,
+  projectId: string,
+  taskId: string,
+  body: string,
+): Promise<ProjectComment> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/projects/${projectId}/tasks/${taskId}/comments`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to post comment: ${response.status}`);
+  }
+
+  const { comment } = (await response.json()) as { comment: ProjectComment };
+  return comment;
+}

--- a/lib/projects/formatTaskDate.ts
+++ b/lib/projects/formatTaskDate.ts
@@ -1,0 +1,19 @@
+/**
+ * A task date as a short calendar day, "Sep 12".
+ *
+ * `due_date` arrives as a bare `YYYY-MM-DD`, which `new Date()` reads as UTC
+ * midnight — rendered in a negative-offset timezone that shows the day before.
+ * A bare date is therefore split by hand instead of parsed.
+ */
+export function formatTaskDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+
+  const bareDate = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  const date = bareDate
+    ? new Date(Number(bareDate[1]), Number(bareDate[2]) - 1, Number(bareDate[3]))
+    : new Date(value);
+
+  if (Number.isNaN(date.getTime())) return null;
+
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/lib/projects/getProject.ts
+++ b/lib/projects/getProject.ts
@@ -1,0 +1,27 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { ProjectResponse } from "@/lib/projects/types";
+
+/**
+ * A project with its tasks and collaborators.
+ * @see https://docs.recoupable.dev/api-reference/projects/get
+ *
+ * Returns null on 404, which the API uses both for an unknown id and for a
+ * caller who is not a collaborator — the two are deliberately indistinguishable
+ * so a response cannot be used to discover real project ids.
+ */
+export async function getProject(
+  accessToken: string,
+  projectId: string,
+): Promise<ProjectResponse | null> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/projects/${projectId}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to load project: ${response.status}`);
+  }
+
+  return (await response.json()) as ProjectResponse;
+}

--- a/lib/projects/getProjectTask.ts
+++ b/lib/projects/getProjectTask.ts
@@ -1,0 +1,26 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { ProjectTaskResponse } from "@/lib/projects/types";
+
+/**
+ * One task with its comment feed and the project's collaborators.
+ * @see https://docs.recoupable.dev/api-reference/projects/task-get
+ *
+ * Null on 404, for the same reason as `getProject`.
+ */
+export async function getProjectTask(
+  accessToken: string,
+  projectId: string,
+  taskId: string,
+): Promise<ProjectTaskResponse | null> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/projects/${projectId}/tasks/${taskId}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to load task: ${response.status}`);
+  }
+
+  return (await response.json()) as ProjectTaskResponse;
+}

--- a/lib/projects/getTaskState.ts
+++ b/lib/projects/getTaskState.ts
@@ -1,0 +1,28 @@
+import type { ProjectTask } from "@/lib/projects/types";
+
+export interface TaskState {
+  isComplete: boolean;
+  /** The task is open and waiting on the person looking at it. */
+  needsYou: boolean;
+}
+
+/**
+ * How one task reads to one viewer (app#2048).
+ *
+ * `needsYou` is the whole reason a client opens the link, so it is derived in
+ * one place rather than re-expressed at each render site. A completed task
+ * never needs anyone, even while it still carries an assignee.
+ */
+export function getTaskState(
+  task: ProjectTask,
+  viewerAccountId: string | null,
+): TaskState {
+  const isComplete = Boolean(task.completed_at);
+  return {
+    isComplete,
+    needsYou:
+      !isComplete &&
+      Boolean(viewerAccountId) &&
+      task.assignee_account_id === viewerAccountId,
+  };
+}

--- a/lib/projects/isProjectId.ts
+++ b/lib/projects/isProjectId.ts
@@ -1,0 +1,11 @@
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Whether a `/projects/{param}` segment names a project. Same guard shape as
+ * `lib/tasks/isTaskId.ts`: a non-UUID segment is a not-found rather than a
+ * request the API has to answer.
+ */
+export function isProjectId(param: string): boolean {
+  return UUID_PATTERN.test(param);
+}

--- a/lib/projects/nameInitial.ts
+++ b/lib/projects/nameInitial.ts
@@ -1,0 +1,9 @@
+/**
+ * The single letter an avatar falls back to when there is no image.
+ *
+ * `accounts.name` is blank on most accounts today, so this falls back to a dot
+ * rather than rendering an empty circle or a stray letter from an email.
+ */
+export function nameInitial(name: string | null | undefined): string {
+  return name?.trim()?.[0]?.toUpperCase() ?? "·";
+}

--- a/lib/projects/setProjectTaskComplete.ts
+++ b/lib/projects/setProjectTaskComplete.ts
@@ -1,0 +1,36 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { ProjectTask } from "@/lib/projects/types";
+
+/**
+ * Mark a task complete or reopen it.
+ * @see https://docs.recoupable.dev/api-reference/projects/task-update
+ *
+ * Sends the `completed` boolean rather than a timestamp: the server stamps
+ * `completed_at` and records `completed_by` from the caller, so who closed an
+ * item is never ambiguous.
+ */
+export async function setProjectTaskComplete(
+  accessToken: string,
+  projectId: string,
+  taskId: string,
+  completed: boolean,
+): Promise<ProjectTask> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/projects/${projectId}/tasks/${taskId}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ completed }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to update task: ${response.status}`);
+  }
+
+  const { task } = (await response.json()) as { task: ProjectTask };
+  return task;
+}

--- a/lib/projects/splitProjectTasks.ts
+++ b/lib/projects/splitProjectTasks.ts
@@ -1,0 +1,33 @@
+import { getTaskState } from "@/lib/projects/getTaskState";
+import type { ProjectTask } from "@/lib/projects/types";
+
+export interface SplitTasks {
+  /** Open tasks waiting on the viewer, pinned above the rest. */
+  needsYou: ProjectTask[];
+  /** Every other open task, in creation order. */
+  active: ProjectTask[];
+  completed: ProjectTask[];
+}
+
+/**
+ * Split a project's tasks into what the two tabs render (app#2048).
+ *
+ * Pinning happens here rather than in the list so the ordering rule lives in
+ * one testable place: what the client owes us comes first, everything else
+ * keeps the order the timeline was written in.
+ */
+export function splitProjectTasks(
+  tasks: ProjectTask[],
+  viewerAccountId: string | null,
+): SplitTasks {
+  const split: SplitTasks = { needsYou: [], active: [], completed: [] };
+
+  for (const task of tasks) {
+    const { isComplete, needsYou } = getTaskState(task, viewerAccountId);
+    if (isComplete) split.completed.push(task);
+    else if (needsYou) split.needsYou.push(task);
+    else split.active.push(task);
+  }
+
+  return split;
+}

--- a/lib/projects/types.ts
+++ b/lib/projects/types.ts
@@ -1,0 +1,58 @@
+/**
+ * The shapes `api.recoupable.dev` returns for a client project, as documented
+ * in recoupable/docs#326. Declared here rather than derived from
+ * `database.types.ts` because the app only ever sees the API's response, never
+ * the table — the same reason `lib/recoup/getArtistProfile.ts` declares its own.
+ */
+
+export interface ProjectCollaborator {
+  account_id: string;
+  /** `accounts.name`, frequently null today. Render a fallback. */
+  name?: string | null;
+}
+
+export interface ProjectTask {
+  id: string;
+  project_id: string;
+  title: string;
+  description?: string | null;
+  /** A calendar date, `2026-09-12`. No time of day. */
+  due_date?: string | null;
+  /** Who the task waits on. Drives the "needs you" treatment. */
+  assignee_account_id?: string | null;
+  /** Null means open. This field is the completed state. */
+  completed_at?: string | null;
+  completed_by?: string | null;
+  comment_count?: number;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+export interface ProjectComment {
+  id: string;
+  task_id: string;
+  account_id: string;
+  author_name?: string | null;
+  body: string;
+  created_at: string;
+}
+
+export interface ProjectResponse {
+  status: string;
+  project: Project;
+  tasks: ProjectTask[];
+  collaborators: ProjectCollaborator[];
+}
+
+export interface ProjectTaskResponse {
+  status: string;
+  task: ProjectTask;
+  comments: ProjectComment[];
+  collaborators: ProjectCollaborator[];
+}


### PR DESCRIPTION
Implements the `app` row of [#2048](https://github.com/recoupable/app/issues/2048), against the [approved design frames](https://github.com/recoupable/app/issues/2048#issuecomment-5494723736).

**Merges last.** Contract [recoupable/docs#326](https://github.com/recoupable/docs/pull/326) → tables [recoupable/database#68](https://github.com/recoupable/database/pull/68) → the three `api` PRs → this. The pages will 404 until the endpoints exist.

## What ships

| Route | Renders |
|---|---|
| `/projects/{projectId}` | The task timeline. Active and Completed tabs, the viewer's own open tasks pinned above Active. |
| `/projects/{projectId}/tasks/{taskId}` | One task: status, due date, description, the completion toggle, and Messages / Documents / Collaborators. |

## Structure

Mirrors `app/tasks/*` rather than inventing a pattern: a two-line route wrapper around a client component, a UUID guard that `notFound()`s a bad segment (`isProjectId`, same shape as `isTaskId`), `PageContainer` for the column, and `RunPageSkeleton` while the query is pending.

Data comes from `api.recoupable.dev` over the Privy access token — the same Bearer credential the rest of the app already sends, so there is no new auth path.

## The decisions worth reviewing

**Pinning lives in `splitProjectTasks`, not in the list.** A client opens this link to find out what is being asked of them, so that ordering rule is one tested function rather than something re-expressed at each render site. A completed task never needs anyone, even while it still carries an assignee.

**`isPending`, not `isLoading`.** `isLoading` is false during the window where the query is disabled waiting on Privy, so gating on it flashes the not-found copy before the fetch runs. That is the exact bug [#2041](https://github.com/recoupable/app/pull/2041) fixed on the task page.

**Not-found copy keeps the API's ambiguity.** The endpoints answer 404 both for an unknown id and for a caller who is not a collaborator, and the page says the same thing for both. Telling someone a project exists but is not theirs is how a project id gets confirmed.

**Dates are split by hand, not parsed.** `due_date` arrives as a bare `YYYY-MM-DD`, which `new Date()` reads as UTC midnight and renders as the day before in any negative-offset timezone. There is a test for it.

## Two deliberate deviations from the approved frames

1. **No "Powered by Recoupable" footer.** The frames were drawn when this was a public capability-URL page. It is now Privy-gated inside the app shell, so it takes the app's chrome like `/tasks` does.
2. **No client-org eyebrow above the title.** It was backed by `projects.client_name`, which was cut in schema review. The project name carries it.

## Verification

- `vitest`: 12 tests over 4 files, all passing. Written test-first with RED confirmed for `isProjectId`, `getTaskState` and `formatTaskDate`; `splitProjectTasks` was written alongside its test.
- `tsc --noEmit`: clean for every file in this diff.
- `eslint`: clean.
- **Not yet preview-verified** — the endpoints do not exist. A full walk (dark desktop → light desktop → mobile, in one login session) with screenshots follows once the `api` PRs are on `main`, and this PR should not merge before that comment is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTaK5sDuryYsQG5W56mR5n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client project status pages for issue #2048 at `/projects/{projectId}` and `/projects/{projectId}/tasks/{taskId}`. Clients previously had no project timeline or task detail view; they can now track progress, see tasks assigned to them, comment, and mark tasks complete or incomplete. The pages return 404 until the underlying project API endpoints are deployed.

**Bug Fixes**

- The shared `Progress` component now emits `aria-valuenow` with a rounded whole-percent value; every progress bar in the app, including CatalogSongsResult's, now reports its value to screen readers.

**New Features**

- Pins the viewer's open assigned tasks above the Active list and keeps completed tasks in a separate tab.
- Shows task progress, due dates, comments, collaborators, and a Documents empty state.
- Validates UUID route parameters and keeps unknown and inaccessible projects indistinguishable.
- Adds focused tests for task grouping, task state, date formatting, and route validation.

<sup>Written for commit 20e3688c995152fbe52f7eabbbc16dc7ddcf212e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project pages with task progress, active and completed tabs, and “Needs you” indicators.
  * Added task detail pages with status controls, due dates, descriptions, breadcrumbs, comments, documents, and collaborators.
  * Added the ability to post comments and mark tasks complete or incomplete.
  * Added loading, empty, and not-found states for projects and tasks.
  * Invalid project or task links now display a not-found page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->