### PR TITLE
fix(projects): preserve line breaks in a task description

### DIFF
--- a/components/ProjectPage/Task/ProjectTaskHeader.tsx
+++ b/components/ProjectPage/Task/ProjectTaskHeader.tsx
@@ -38,7 +38,9 @@ const ProjectTaskHeader = ({
         )}
       </div>
       {task.description && (
-        <p className="text-[15px] leading-relaxed">{task.description}</p>
+        <p className="whitespace-pre-line text-[15px] leading-relaxed">
+          {task.description}
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
Follow-up to [app#2049](https://github.com/recoupable/app/pull/2049), tracking issue [app#2048](https://github.com/recoupable/app/issues/2048).

## The problem

`ProjectTaskHeader` renders the description as a plain `<p>`, so newlines collapse:

```
<p className="text-[15px] leading-relaxed">{task.description}</p>
```

A task whose description is a numbered list of console steps arrives as one run-on paragraph. `ProjectCommentList` already sets `whitespace-pre-line` on comment bodies, so the two halves of the same page disagreed.

## Why it matters now, not hypothetically

Found while seeding the first real client project. Three of its eleven tasks are things only the client can do in the AWS console, and each is a short click path:

```
1. Sign in as the account owner, not an IAM user.
2. Go to https://console.aws.amazon.com/costmanagement/home#/settings
3. Find "Rightsizing recommendations" on that page.
4. Check the box, then Save preferences.
```

Without this fix those steps either stay locked in an attached PDF or land unreadable. The whole point of the page is that the client can act from it.

## Scope

One line. The list row's description is deliberately left single-line: it is a one-line preview, and how it should clamp is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpcHy63mJgvXYmwKcgsn9i

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Task descriptions previously collapsed newlines into a single run-on paragraph. They now render with line breaks preserved via `whitespace-pre-line`, matching comment bodies on the same page. The list row preview stays single-line on purpose.

<sup>Written for commit 1558f8a026c68396c7b1b9fd6088fd51ccdfd866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task descriptions now preserve line breaks and spacing, improving readability of formatted text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->