### PR TITLE
feat(chat): bash tool component, ported from open-agents

### DIFF
--- a/components/VercelChat/MessageParts.tsx
+++ b/components/VercelChat/MessageParts.tsx
@@ -39,6 +39,13 @@ export function MessageParts({
   const ctx = useContext(VercelChatContext);
   const status = statusProp ?? ctx?.status;
   const reload = reloadProp ?? ctx?.reload ?? (() => {});
+  // `status` is chat-wide. A tool part left mid-run by a stopped earlier turn
+  // must not spin again when a later turn streams, so only the message that
+  // owns the stream counts as streaming.
+  const messages = ctx?.messages;
+  const isOwnStream =
+    status === "streaming" &&
+    (!messages || messages[messages.length - 1]?.id === message.id);
   return (
     <div className={cn("flex flex-col gap-4 w-full group")}>
       {message.parts?.map(
@@ -136,8 +143,8 @@ export function MessageParts({
             const isTerminal =
               state === "output-available" || state === "output-error";
             return isTerminal
-              ? getToolResultComponent(part as ToolUIPart, status === "streaming")
-              : getToolCallComponent(part as ToolUIPart, status === "streaming");
+              ? getToolResultComponent(part as ToolUIPart, isOwnStream)
+              : getToolCallComponent(part as ToolUIPart, isOwnStream);
           }
         },
       )}

--- a/components/VercelChat/MessageParts.tsx
+++ b/components/VercelChat/MessageParts.tsx
@@ -130,11 +130,14 @@ export function MessageParts({
 
           if (isToolOrDynamicToolUIPart(part)) {
             const { state } = part as ToolUIPart;
-            if (state !== "output-available") {
-              return getToolCallComponent(part as ToolUIPart);
-            } else {
-              return getToolResultComponent(part as ToolUIPart);
-            }
+            // `output-error` is terminal. Routing it to the call branch — the
+            // loading one — rendered a skeleton that could never resolve
+            // (recoupable/app#2052).
+            const isTerminal =
+              state === "output-available" || state === "output-error";
+            return isTerminal
+              ? getToolResultComponent(part as ToolUIPart, status === "streaming")
+              : getToolCallComponent(part as ToolUIPart, status === "streaming");
           }
         },
       )}

--- a/components/VercelChat/ToolComponents.tsx
+++ b/components/VercelChat/ToolComponents.tsx
@@ -72,6 +72,8 @@ import {
 } from "./tools/files/UpdateFileResult";
 import ComposioAuthResult from "./tools/composio/ComposioAuthResult";
 import { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import { extractToolRenderState } from "@/lib/chat/extractToolRenderState";
+import { BashRenderer, type BashOutput } from "./tools/agent/BashRenderer";
 import PulseToolSkeleton from "./tools/pulse/PulseToolSkeleton";
 import PulseToolResult, {
   PulseToolResultType,
@@ -85,10 +87,21 @@ type CallToolResult = {
   content: TextContent[];
 };
 
-export function getToolCallComponent(part: ToolUIPart) {
+export function getToolCallComponent(part: ToolUIPart, isStreaming = true) {
   const { toolCallId } = part as ToolUIPart;
   const toolName = getToolOrDynamicToolName(part);
   const isSearchWebTool = toolName === "search_web";
+
+  if (toolName === "bash") {
+    return (
+      <div key={toolCallId}>
+        <BashRenderer
+          input={part.input as { command?: string; cwd?: string; detached?: boolean }}
+          state={extractToolRenderState(part, isStreaming)}
+        />
+      </div>
+    );
+  }
 
   if (toolName === "generate_image" || toolName === "edit_image") {
     return (
@@ -209,8 +222,25 @@ export function getToolCallComponent(part: ToolUIPart) {
   );
 }
 
-export function getToolResultComponent(part: ToolUIPart | DynamicToolUIPart) {
+export function getToolResultComponent(
+  part: ToolUIPart | DynamicToolUIPart,
+  isStreaming = false,
+) {
   const { toolCallId, output, type } = part;
+  const toolNameEarly = getToolOrDynamicToolName(part);
+
+  if (toolNameEarly === "bash") {
+    return (
+      <div key={toolCallId}>
+        <BashRenderer
+          input={part.input as { command?: string; cwd?: string; detached?: boolean }}
+          output={output as BashOutput | undefined}
+          state={extractToolRenderState(part, isStreaming)}
+        />
+      </div>
+    );
+  }
+
   const isMcp = type === "dynamic-tool";
   const result = isMcp
     ? JSON.parse((output as CallToolResult).content[0].text)

--- a/components/VercelChat/ToolComponents.tsx
+++ b/components/VercelChat/ToolComponents.tsx
@@ -74,6 +74,7 @@ import ComposioAuthResult from "./tools/composio/ComposioAuthResult";
 import { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import { extractToolRenderState } from "@/lib/chat/extractToolRenderState";
 import { BashRenderer, type BashOutput } from "./tools/agent/BashRenderer";
+import { ToolLayout } from "./tools/agent/ToolLayout";
 import PulseToolSkeleton from "./tools/pulse/PulseToolSkeleton";
 import PulseToolResult, {
   PulseToolResultType,
@@ -96,7 +97,9 @@ export function getToolCallComponent(part: ToolUIPart, isStreaming = true) {
     return (
       <div key={toolCallId}>
         <BashRenderer
-          input={part.input as { command?: string; cwd?: string; detached?: boolean }}
+          input={
+            part.input as { command?: string; cwd?: string; detached?: boolean }
+          }
           state={extractToolRenderState(part, isStreaming)}
         />
       </div>
@@ -233,8 +236,23 @@ export function getToolResultComponent(
     return (
       <div key={toolCallId}>
         <BashRenderer
-          input={part.input as { command?: string; cwd?: string; detached?: boolean }}
+          input={
+            part.input as { command?: string; cwd?: string; detached?: boolean }
+          }
           output={output as BashOutput | undefined}
+          state={extractToolRenderState(part, isStreaming)}
+        />
+      </div>
+    );
+  }
+
+  // A tool that threw has `errorText` and no `output`; every branch below
+  // reads the output, so route the error to the shared row first.
+  if (part.state === "output-error") {
+    return (
+      <div key={toolCallId}>
+        <ToolLayout
+          name={toolNameEarly}
           state={extractToolRenderState(part, isStreaming)}
         />
       </div>

--- a/components/VercelChat/__tests__/MessageParts.toolRouting.test.tsx
+++ b/components/VercelChat/__tests__/MessageParts.toolRouting.test.tsx
@@ -12,7 +12,7 @@ const message = (
   {
     id = "m1",
     tool = "bash",
-    input = { command: "pnpm exec tsc --noEmit" },
+    input = { command: "pnpm exec tsc --noEmit" } as Record<string, unknown>,
   } = {},
 ) =>
   ({

--- a/components/VercelChat/__tests__/MessageParts.toolRouting.test.tsx
+++ b/components/VercelChat/__tests__/MessageParts.toolRouting.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import { MessageParts } from "@/components/VercelChat/MessageParts";
+
+const message = (state: string, extra: Record<string, unknown> = {}) =>
+  ({
+    id: "m1",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-bash",
+        toolCallId: "call-1",
+        state,
+        input: { command: "pnpm exec tsc --noEmit" },
+        ...extra,
+      },
+    ],
+  }) as unknown as UIMessage;
+
+const renderParts = (m: UIMessage) =>
+  render(<MessageParts message={m} mode="view" setMode={() => {}} status="ready" reload={() => {}} />);
+
+describe("MessageParts — sandbox tool routing (app#2052)", () => {
+  it("renders a terminal output-error as an error, not a spinner", () => {
+    const { container } = renderParts(
+      message("output-error", { errorText: "Sandbox not found: sbx_9f2c1a" }),
+    );
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(screen.getByText("Bash")).toBeTruthy();
+  });
+
+  it("does not present a non-zero exit as a success", () => {
+    renderParts(
+      message("output-available", {
+        output: { success: false, exitCode: 2, stdout: "", stderr: "error TS2345" },
+      }),
+    );
+    expect(screen.getByText("exit 2")).toBeTruthy();
+  });
+
+  it("shows the command as the summary", () => {
+    renderParts(message("output-available", { output: { success: true, exitCode: 0, stdout: "ok" } }));
+    expect(screen.getByText("pnpm exec tsc --noEmit")).toBeTruthy();
+  });
+});

--- a/components/VercelChat/__tests__/MessageParts.toolRouting.test.tsx
+++ b/components/VercelChat/__tests__/MessageParts.toolRouting.test.tsx
@@ -1,48 +1,117 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { UIMessage } from "ai";
 import { MessageParts } from "@/components/VercelChat/MessageParts";
+import { VercelChatContext } from "@/providers/VercelChatProvider";
 
-const message = (state: string, extra: Record<string, unknown> = {}) =>
+const message = (
+  state: string,
+  extra: Record<string, unknown> = {},
+  {
+    id = "m1",
+    tool = "bash",
+    input = { command: "pnpm exec tsc --noEmit" },
+  } = {},
+) =>
   ({
-    id: "m1",
+    id,
     role: "assistant",
     parts: [
       {
-        type: "tool-bash",
-        toolCallId: "call-1",
+        type: `tool-${tool}`,
+        toolCallId: `call-${id}`,
         state,
-        input: { command: "pnpm exec tsc --noEmit" },
+        input,
         ...extra,
       },
     ],
   }) as unknown as UIMessage;
 
 const renderParts = (m: UIMessage) =>
-  render(<MessageParts message={m} mode="view" setMode={() => {}} status="ready" reload={() => {}} />);
+  render(
+    <MessageParts
+      message={m}
+      mode="view"
+      setMode={() => {}}
+      status="ready"
+      reload={() => {}}
+    />,
+  );
 
 describe("MessageParts — sandbox tool routing (app#2052)", () => {
-  it("renders a terminal output-error as an error, not a spinner", () => {
+  it("renders a non-bash output-error as an error row instead of crashing on a missing output", () => {
+    // Before app#2055, output-error went to the loading branch (a skeleton that
+    // never resolved). Routing it to the result branch must not hand the
+    // success renderer an undefined output.
+    const { container } = renderParts(
+      message(
+        "output-error",
+        { errorText: "Sandbox not found: sbx_9f2c1a" },
+        { tool: "read", input: { path: "README.md" } },
+      ),
+    );
+    expect(container.querySelector(".skeleton")).toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(container.querySelector("svg.lucide-circle-x")).toBeTruthy();
+    fireEvent.click(container.querySelector('[role="button"]')!);
+    expect(screen.getByText("Sandbox not found: sbx_9f2c1a")).toBeTruthy();
+  });
+
+  it("renders a bash output-error with the error icon, not a spinner", () => {
     const { container } = renderParts(
       message("output-error", { errorText: "Sandbox not found: sbx_9f2c1a" }),
     );
     expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(container.querySelector("svg.lucide-circle-x")).toBeTruthy();
     expect(screen.getByText("Bash")).toBeTruthy();
   });
 
   it("does not present a non-zero exit as a success", () => {
     renderParts(
       message("output-available", {
-        output: { success: false, exitCode: 2, stdout: "", stderr: "error TS2345" },
+        output: {
+          success: false,
+          exitCode: 2,
+          stdout: "",
+          stderr: "error TS2345",
+        },
       }),
     );
     expect(screen.getByText("exit 2")).toBeTruthy();
   });
 
   it("shows the command as the summary", () => {
-    renderParts(message("output-available", { output: { success: true, exitCode: 0, stdout: "ok" } }));
+    renderParts(
+      message("output-available", {
+        output: { success: true, exitCode: 0, stdout: "ok" },
+      }),
+    );
     expect(screen.getByText("pnpm exec tsc --noEmit")).toBeTruthy();
+  });
+
+  it("does not spin an abandoned command from an earlier turn while a later turn streams", () => {
+    const abandoned = message(
+      "input-available",
+      {},
+      { id: "old", input: { command: "sleep 45" } },
+    );
+    const current = message(
+      "input-available",
+      {},
+      { id: "new", input: { command: "ls" } },
+    );
+    const ctx = {
+      status: "streaming",
+      messages: [abandoned, current],
+    } as unknown as React.ContextType<typeof VercelChatContext>;
+    const { container } = render(
+      <VercelChatContext.Provider value={ctx}>
+        <MessageParts message={abandoned} mode="view" setMode={() => {}} />
+      </VercelChatContext.Provider>,
+    );
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(container.querySelector("svg.lucide-octagon-pause")).toBeTruthy();
   });
 });

--- a/components/VercelChat/tools/agent/BashRenderer.tsx
+++ b/components/VercelChat/tools/agent/BashRenderer.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Terminal } from "lucide-react";
+import type { ToolRenderState } from "@/lib/chat/extractToolRenderState";
+import { ToolLayout } from "./ToolLayout";
+
+/** What `bashTool` returns from the sandbox. */
+export interface BashOutput {
+  success?: boolean;
+  exitCode?: number | null;
+  stdout?: string;
+  stderr?: string;
+  truncated?: boolean;
+}
+
+export interface BashRendererProps {
+  input?: { command?: string; cwd?: string; detached?: boolean };
+  output?: BashOutput;
+  state: ToolRenderState;
+}
+
+/**
+ * The sandbox agent's work is almost entirely `bash`, so this is the row a
+ * reader sees most. The command is the summary; a non-zero exit turns the whole
+ * row destructive and puts the code on the right.
+ *
+ * Ported from `open-agents` (`renderers/bash-renderer.tsx`) — its output shape
+ * is already exactly ours. See recoupable/app#2052.
+ */
+export function BashRenderer({ input, output, state }: BashRendererProps) {
+  const command = String(input?.command ?? "");
+  const { exitCode, stdout, stderr } = output ?? {};
+  // A command that exits non-zero used to render a green check, because the
+  // default result branch never read the output at all.
+  const failed =
+    output?.success === false || (typeof exitCode === "number" && exitCode !== 0);
+
+  const combined = [stdout, stderr].filter(Boolean).join("\n").trim();
+  const mergedState: ToolRenderState =
+    failed && !state.error
+      ? { ...state, error: `Exit code ${exitCode ?? "unknown"}` }
+      : state;
+
+  const expandedContent = output ? (
+    <pre
+      className={
+        failed
+          ? "max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 font-mono text-xs leading-relaxed text-destructive"
+          : "max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/50 p-3 font-mono text-xs leading-relaxed text-muted-foreground"
+      }
+    >
+      {combined || "(No output)"}
+      {output.truncated ? "\n…output truncated" : ""}
+    </pre>
+  ) : undefined;
+
+  return (
+    <ToolLayout
+      name="Bash"
+      summary={command || "…"}
+      icon={<Terminal className="h-3.5 w-3.5" />}
+      meta={
+        failed && exitCode !== undefined && exitCode !== null ? (
+          `exit ${exitCode}`
+        ) : input?.detached ? (
+          <span className="rounded-full bg-blue-500/12 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-400">
+            detached
+          </span>
+        ) : undefined
+      }
+      state={mergedState}
+      expandedContent={expandedContent}
+    />
+  );
+}

--- a/components/VercelChat/tools/agent/ToolLayout.tsx
+++ b/components/VercelChat/tools/agent/ToolLayout.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { type ReactNode, useState } from "react";
+import { CircleX, Loader2, Minus, OctagonPause, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ToolRenderState } from "@/lib/chat/extractToolRenderState";
+
+export interface ToolLayoutProps {
+  /** Tool label, e.g. "Bash". */
+  name: string;
+  /** The one-line summary — for bash, the command itself. */
+  summary?: ReactNode;
+  /** Right-aligned detail such as an exit code. */
+  meta?: ReactNode;
+  state: ToolRenderState;
+  /** Revealed on click; the row is inert when this is absent. */
+  expandedContent?: ReactNode;
+  icon?: ReactNode;
+}
+
+/**
+ * One dense row per tool call: icon, name, mono summary, right-aligned meta,
+ * click to expand.
+ *
+ * Ported from `open-agents` (`apps/web/components/tool-call/tool-layout.tsx`),
+ * retokenised to this app's variables. Density is the design constraint — the
+ * agent emits many calls per turn, so a row is ~24px and the command *is* the
+ * summary. See recoupable/app#2052.
+ */
+export function ToolLayout({
+  name,
+  summary,
+  meta,
+  state,
+  expandedContent,
+  icon,
+}: ToolLayoutProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasError = Boolean(state.error);
+  const canExpand = Boolean(expandedContent) || hasError;
+  const tone = hasError
+    ? "text-destructive"
+    : state.interrupted
+      ? "text-amber-600 dark:text-amber-500"
+      : "text-foreground";
+
+  const leading = state.running ? (
+    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+  ) : hasError ? (
+    <CircleX className="h-3.5 w-3.5 text-destructive" />
+  ) : state.interrupted ? (
+    <OctagonPause className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500" />
+  ) : (
+    (icon ?? <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />)
+  );
+
+  return (
+    <div className="-mx-1.5">
+      <div
+        className={cn(
+          "group flex min-w-0 select-none items-center gap-2 rounded-md px-1.5 py-1 text-sm",
+          canExpand && "cursor-pointer transition-colors hover:bg-muted/50",
+        )}
+        {...(canExpand && {
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+          onClick: () => setIsExpanded((v) => !v),
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setIsExpanded((v) => !v);
+            }
+          },
+        })}
+      >
+        <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/70">
+          {canExpand && !state.running ? (
+            <>
+              <span className="group-hover:hidden">{leading}</span>
+              {isExpanded ? (
+                <Minus className="hidden h-3.5 w-3.5 group-hover:block" />
+              ) : (
+                <Plus className="hidden h-3.5 w-3.5 group-hover:block" />
+              )}
+            </>
+          ) : (
+            leading
+          )}
+        </span>
+
+        <span className={cn("shrink-0 font-medium leading-none", tone)}>{name}</span>
+
+        {summary != null && (
+          <span className="min-w-0 flex-1 truncate font-mono text-[13px] leading-none text-muted-foreground">
+            {summary}
+          </span>
+        )}
+
+        {meta != null && (
+          <span className="shrink-0 font-mono text-xs leading-none text-muted-foreground/70">
+            {meta}
+          </span>
+        )}
+      </div>
+
+      {isExpanded && canExpand && (
+        <div className="mt-1.5 space-y-2 pb-1">
+          {hasError && !expandedContent && (
+            <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 font-mono text-xs leading-relaxed text-destructive">
+              {state.error}
+            </pre>
+          )}
+          {expandedContent}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/chat/__tests__/extractToolRenderState.test.ts
+++ b/lib/chat/__tests__/extractToolRenderState.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extractToolRenderState } from "@/lib/chat/extractToolRenderState";
+
+describe("extractToolRenderState", () => {
+  it("is running while the stream is live", () => {
+    expect(extractToolRenderState({ state: "input-available" }, true)).toEqual({
+      running: true,
+      interrupted: false,
+      error: undefined,
+    });
+  });
+
+  // The bug this exists to prevent: a tool left mid-run when the stream ends
+  // must never render as still running.
+  it("is interrupted, not running, once the stream has ended", () => {
+    const s = extractToolRenderState({ state: "input-streaming" }, false);
+    expect(s.running).toBe(false);
+    expect(s.interrupted).toBe(true);
+  });
+
+  it("surfaces errorText on output-error", () => {
+    expect(
+      extractToolRenderState({ state: "output-error", errorText: "Sandbox not found" }, true).error,
+    ).toBe("Sandbox not found");
+  });
+
+  it("is neither running nor interrupted once output is available", () => {
+    expect(extractToolRenderState({ state: "output-available" }, false)).toEqual({
+      running: false,
+      interrupted: false,
+      error: undefined,
+    });
+  });
+});

--- a/lib/chat/extractToolRenderState.ts
+++ b/lib/chat/extractToolRenderState.ts
@@ -1,0 +1,42 @@
+export interface ToolRenderState {
+  /** Actively executing right now. */
+  running: boolean;
+  /** Was running when the stream ended, so it will never resolve. */
+  interrupted: boolean;
+  /** Error text when the tool threw. */
+  error?: string;
+}
+
+export interface RenderableToolPart {
+  state: string;
+  errorText?: string;
+}
+
+/**
+ * Derive what a tool row should show from its part and the stream's state.
+ *
+ * Ported from `open-agents` (`packages/shared/lib/tool-state.ts`), trimmed of
+ * the approval machinery our agent does not have.
+ *
+ * `interrupted` is the reason this is a function and not a pair of booleans at
+ * the call site: a tool part that is still in a running state *after the stream
+ * has ended* is not running, it is abandoned. Deriving that centrally is what
+ * makes it impossible to render a spinner that can never resolve.
+ *
+ * @param part - The tool UI part.
+ * @param isStreaming - Whether the assistant turn is still streaming.
+ * @returns The state a renderer should draw.
+ */
+export function extractToolRenderState(
+  part: RenderableToolPart,
+  isStreaming: boolean,
+): ToolRenderState {
+  const isRunningState =
+    part.state === "input-streaming" || part.state === "input-available";
+
+  return {
+    running: isRunningState && isStreaming,
+    interrupted: isRunningState && !isStreaming,
+    error: part.state === "output-error" ? part.errorText : undefined,
+  };
+}


### PR DESCRIPTION
Row 3 of #2052. Design approved — [comment](https://github.com/recoupable/app/issues/2052#issuecomment-5511209213), [canvas](https://claude.ai/code/artifact/df9de3e1-4ee5-4ec4-ad59-9bdd93bc8b77).

## Why

The app has exactly one transport — `createWorkflowChatTransport` → `POST /api/chat` → the sandbox agent, whose tools are `bash, read, write, edit, grep, glob, todo_write, web_fetch, task, ask_user_question, skill`. Every branch in `ToolComponents.tsx` matches an **MCP** tool name (`generate_image`, `retrieve_sora_2_video_content`, …), so **none of them fires**. `bash` fell through to a grey "Using bash" pill, then a generic green check.

## Two correctness bugs this exposed and fixes

1. **A terminal error rendered the loading skeleton forever.** `MessageParts` routed anything that was not `output-available` to `getToolCallComponent`, so AI SDK's terminal `output-error` state got the *loading* branch. Same class as #2036.
2. **A failed command rendered as a success.** The default result branch returned `GenericSuccess` — which hardcodes a check icon — without reading the output. `bashTool` returns `{success, exitCode, stdout, stderr}`, so a command exiting 2 showed a green check.

## The port

From `open-agents` (`apps/web/components/tool-call/`) — Vercel's reference app for this exact architecture, already a submodule here. Its bash renderer reads `{success, exitCode, stdout, stderr}`, which is **exactly** `bashTool`'s return shape, so no adapter.

- `lib/chat/extractToolRenderState.ts` — vendored from `packages/shared/lib/tool-state.ts`, trimmed of approval machinery we do not have. Derives `interrupted = isRunningState && !isStreaming`, which is what structurally prevents a spinner that cannot resolve.
- `components/VercelChat/tools/agent/ToolLayout.tsx` — the shared row, retokenised to this app's variables.
- `components/VercelChat/tools/agent/BashRenderer.tsx` — command as summary, exit code right-aligned, `detached` badge, collapsible merged stdout/stderr, destructive treatment on failure.

**Density is the design constraint,** and why AI Elements' `Tool` was not used: it is a bordered Collapsible with a badge and the input as a JSON `CodeBlock` (~120px per call, `{"command":"ls"}` instead of `ls`). Ours is ~24px. The agent emits many calls per turn.

**The MCP-named branches stay.** Messages persisted before the bash-architecture migration carry those parts and still render in history.

**Provenance:** the ported files are byte-identical to `vercel-labs/open-agents` `main` as of 2026-09-02, apart from the `@open-harness` → `@open-agents` scope rename, which disappears here since `extractRenderState` is vendored.

## Tests

4 cases on `extractToolRenderState` (running, interrupted, error, complete) and 3 on `MessageParts` routing that pin both fixed bugs: an `output-error` renders no spinner, a non-zero exit shows `exit 2` rather than a check, and the command is the summary. All pass; `tsc --noEmit` and eslint clean.

## Preview verification

Pending — draft until verified on the preview for this SHA, with dark, light and mobile screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcNQAfA3nS7BTrMB3bXsnX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sandbox `bash` calls previously fell back to generic pills and showed failed or abandoned calls as successful or still loading; they now render as dense, expandable command rows with accurate exit, error, and interrupted states. This addresses rows 1 and 3 of `recoupable/app#2052` while keeping persisted MCP-named tool parts renderable.

- Reads `bashTool`’s existing `{ success, exitCode, stdout, stderr }` shape without an adapter.
- Shows the command summary, exit code, detached status, and merged output.
- Routes `output-error` through a shared error row before output parsing, so terminal errors do not crash other tool renderers.
- Scopes streaming to the message that owns the active stream, marking stopped earlier turns as interrupted.
- Adds coverage for render states, error routing, failed exits, command summaries, and abandoned calls.

<sup>Written for commit 743a910c8fb046fb8a49301ddc6cf73c950521b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer, compact display for Bash command executions, including commands, working directories, detached status, exit codes, and combined output.
  * Added expandable tool execution rows with status icons, error details, and keyboard accessibility.
  * Added support for displaying truncated command output and empty-output states.

* **Bug Fixes**
  * Tool executions from earlier interrupted turns no longer appear to keep spinning during later responses.
  * Failed and interrupted executions now display terminal status consistently, including output errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->