### PR TITLE
fix(billing): open the Stripe portal via POST /api/accounts/{id}/portal

### DIFF
--- a/hooks/useSubscribeClick.ts
+++ b/hooks/useSubscribeClick.ts
@@ -16,7 +16,7 @@ const useSubscribeClick = () => {
     if (!accessToken) return;
 
     if (isSubscribed) {
-      await createClientPortalSession(accessToken);
+      await createClientPortalSession(accessToken, userData.account_id);
       return;
     }
 

--- a/lib/stripe/__tests__/createClientPortalSession.test.ts
+++ b/lib/stripe/__tests__/createClientPortalSession.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import createClientPortalSession from "@/lib/stripe/createClientPortalSession";
+
+const fetchMock = vi.fn();
+const ACCOUNT_ID = "5d2be75b-b49b-4c2a-ac0a-63d812430dda";
+
+describe("createClientPortalSession", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("open", vi.fn());
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://stripe.test/p" }),
+    });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("posts to the account-scoped portal path with the returnUrl body", async () => {
+    await createClientPortalSession("token", ACCOUNT_ID);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toMatch(new RegExp(`/api/accounts/${ACCOUNT_ID}/portal$`));
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token",
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      returnUrl: window.location.href,
+    });
+  });
+
+  it("opens the returned portal URL", async () => {
+    await createClientPortalSession("token", ACCOUNT_ID);
+    expect(window.open).toHaveBeenCalledWith(
+      "https://stripe.test/p",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("returns the error on a rejected request, a missing url, or a network failure", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+    expect(
+      (await createClientPortalSession("token", ACCOUNT_ID))?.error,
+    ).toBeInstanceOf(Error);
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    expect(
+      (await createClientPortalSession("token", ACCOUNT_ID))?.error,
+    ).toBeInstanceOf(Error);
+    fetchMock.mockRejectedValueOnce(new TypeError("offline"));
+    expect(
+      (await createClientPortalSession("token", ACCOUNT_ID))?.error,
+    ).toBeInstanceOf(TypeError);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+});

--- a/lib/stripe/createClientPortalSession.ts
+++ b/lib/stripe/createClientPortalSession.ts
@@ -1,9 +1,17 @@
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 
-const createClientPortalSession = async (accessToken: string) => {
+/**
+ * Opens the Stripe billing portal for an account via
+ * POST /api/accounts/{accountId}/portal. The account may be the caller's own
+ * or an organization they belong to.
+ */
+const createClientPortalSession = async (
+  accessToken: string,
+  accountId: string,
+) => {
   try {
     const response = await fetch(
-      `${getClientApiBaseUrl()}/api/subscriptions/portal`,
+      `${getClientApiBaseUrl()}/api/accounts/${accountId}/portal`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary

Item of recoupable/app#2062, contract [docs#329](https://github.com/recoupable/docs/pull/329).

- `lib/stripe/createClientPortalSession.ts` takes an `accountId` and posts to `/api/accounts/{accountId}/portal` (body `{ returnUrl }`, Privy bearer) instead of `/api/subscriptions/portal`, which the api is retiring.
- `hooks/useSubscribeClick.ts` passes the caller's own `account_id`. Org mode will pass the selected org id in a later PR.
- No UI change; the dropdown "Billing" item behaves exactly as before once the api route exists.

## Merge order

This PR must be on prod **before** the api PR that deletes `POST /api/subscriptions/portal`. Until the api PR that adds `POST /api/accounts/{id}/portal` (branch `feat/account-portal`) is live, the new path returns 404, so the "Billing" item is briefly non-functional if this merges first. Sequence: api add-route → this → api delete-old-route.

## Verification

- Unit: new `lib/stripe/__tests__/createClientPortalSession.test.ts` (3 tests: URL + method + headers + body, opens returned URL, error paths), RED on the URL assertion before the change, GREEN after; sibling checkout-session suite still 5/5.
- `tsc --noEmit`: no errors in touched files. eslint + prettier clean.
- Live 200 depends on the api route; results comment below states what was and was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzdC6dwcNjQrNTQEcBsmRz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the billing portal flow to open the Stripe portal for the selected account.
  * Improved account-specific billing access by using the account identifier when creating portal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the Stripe billing portal via `POST /api/accounts/{accountId}/portal` instead of the retiring `/api/subscriptions/portal`. `useSubscribeClick` now passes the caller's own `account_id`; org-scoped accounts come in a later PR. No UI change.

**Migration**
- Merge order matters: the API route must be live before this deploys, or the Billing item briefly returns 404. Sequence is API add-route → this PR → API delete-old-route.

<sup>Written for commit 2a32e34e9dbc525fade3057b7b0a51d5e2e60991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

