### PR TITLE
fix(ui): make an off Switch visible in dark mode

### DIFF
--- a/components/ui/__tests__/switch.test.tsx
+++ b/components/ui/__tests__/switch.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Switch } from "@/components/ui/switch";
+
+// An off switch in dark mode used to be a black thumb on a card-colored
+// track inside a card: invisible. The track and thumb must keep the
+// upstream shadcn contrast rule in both states.
+describe("Switch", () => {
+  const thumbOf = (root: HTMLElement) => root.firstElementChild as HTMLElement;
+
+  it("never paints the unchecked track with the card color or the thumb black", () => {
+    render(<Switch aria-label="Auto top-up" />);
+    const root = screen.getByRole("switch");
+    expect(root.className).not.toContain("bg-card");
+    expect(thumbOf(root).className).not.toContain("bg-black");
+  });
+
+  it("gives the dark unchecked thumb the foreground color and the track the input color", () => {
+    render(<Switch aria-label="Auto top-up" />);
+    const root = screen.getByRole("switch");
+    expect(root.className).toContain("data-[state=unchecked]:bg-input");
+    expect(thumbOf(root).className).toContain(
+      "dark:data-[state=unchecked]:bg-foreground",
+    );
+  });
+
+  it("keeps the dark checked thumb dark on the light primary track", () => {
+    render(<Switch aria-label="Auto top-up" checked />);
+    const root = screen.getByRole("switch");
+    expect(root.className).toContain("data-[state=checked]:bg-primary");
+    expect(thumbOf(root).className).toContain(
+      "dark:data-[state=checked]:bg-primary-foreground",
+    );
+  });
+});

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-card",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
       className
     )}
     {...props}
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background dark:bg-black shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-4 w-4 rounded-full bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
Row 16 of recoupable/app#2062.

## Why

An off toggle in dark mode was invisible: `components/ui/switch.tsx` carried two local overrides on top of shadcn, an unchecked track painted `bg-card` and a thumb painted black, so inside a card (the Auto top-up switch on `/billing`) it was black on black. Disabled made it fainter still.

## What

- Track: `data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80` (the `bg-card` override is gone).
- Thumb: `bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground` (the black override is gone).

These are the upstream shadcn Switch classes. Light mode is unchanged. The change reaches every Switch in the app: Auto top-up on `/billing`, the Pulse toggle, agent privacy, and the hide-missing-items toggle in catalog results.

## Tests

`components/ui/__tests__/switch.test.tsx`: no `bg-card` track or black thumb; dark unchecked thumb is foreground on an input track; dark checked thumb is primary-foreground on the primary track. Red before, green after.

## Verification

Preview walk with screenshots to follow in a comment: `/billing` dark with the switch off and disabled, on, and light mode; one other Switch consumer for regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzdC6dwcNjQrNTQEcBsmRz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an off `Switch` being invisible in dark mode: the previous `bg-card` track and black thumb made it black on black inside cards, and now the component uses the upstream shadcn classes (`bg-input/80` track, `foreground` thumb in dark unchecked, `primary-foreground` in dark checked). Light mode is unchanged, and the fix applies to every Switch in the app, with new tests covering the dark-state colors.

<sup>Written for commit 4ec21c79bf6a13d0221480130a94d0bd1dd24b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

