### PR TITLE
feat(billing): tooltip explains the disabled Auto top-up switch

### DIFF
--- a/components/BillingPage/AutoTopUpPanel.tsx
+++ b/components/BillingPage/AutoTopUpPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
+import AutoTopUpSwitch from "./AutoTopUpSwitch";
 import BillingPanel from "./BillingPanel";
 import MoneyInput from "./MoneyInput";
 import type { AutoTopUpSettings } from "@/lib/recoup/getAccountAutoTopUp";
@@ -10,7 +10,7 @@ import toDollars from "@/lib/billing/toDollars";
 import toCents from "@/lib/billing/toCents";
 import describeAutoTopUpHint from "./describeAutoTopUpHint";
 
-/** Toggle, amount, threshold and Save; disabled with a hint until a card is on file. */
+/** Toggle, amount, threshold and Save; disabled with a hint and a tooltip until a card is on file. */
 const AutoTopUpPanel = ({
   settings,
   hasCard,
@@ -40,11 +40,11 @@ const AutoTopUpPanel = ({
     <BillingPanel
       title="Auto top-up"
       aside={
-        <Switch
-          checked={hasCard && enabled}
-          onCheckedChange={setEnabled}
-          disabled={!hasCard || isSaving}
-          aria-label="Auto top-up"
+        <AutoTopUpSwitch
+          hasCard={hasCard}
+          enabled={enabled}
+          onToggle={setEnabled}
+          isSaving={isSaving}
         />
       }
     >

--- a/components/BillingPage/AutoTopUpSwitch.tsx
+++ b/components/BillingPage/AutoTopUpSwitch.tsx
@@ -8,11 +8,13 @@ import {
 } from "@/components/ui/tooltip";
 
 const NO_CARD = "Add a card under Payment method to turn on auto top-up.";
+const HINT_ID = "auto-top-up-no-card-hint";
 
 /**
  * The Auto top-up toggle. Without a card it is disabled and a tooltip says
  * why: a disabled control gets no pointer events, so a focusable wrapper is
- * the trigger, and a tap toggles it for touch screens where hover never comes.
+ * the trigger (hover, keyboard focus, and a tap for touch screens all open
+ * it), and the switch itself is described by the same text for screen readers.
  */
 const AutoTopUpSwitch = ({
   hasCard,
@@ -32,6 +34,7 @@ const AutoTopUpSwitch = ({
       onCheckedChange={onToggle}
       disabled={!hasCard || isSaving}
       aria-label="Auto top-up"
+      aria-describedby={hasCard ? undefined : HINT_ID}
       className={hasCard ? undefined : "pointer-events-none"}
     />
   );
@@ -43,11 +46,18 @@ const AutoTopUpSwitch = ({
           <span
             tabIndex={0}
             data-testid="auto-top-up-no-card"
-            aria-label={NO_CARD}
             className="inline-flex cursor-not-allowed rounded-full"
-            onClick={() => setOpen((value) => !value)}
+            // preventDefault keeps Radix's own click-to-close out of the chain;
+            // closing is by Escape, blur, or a tap outside.
+            onClick={(event) => {
+              event.preventDefault();
+              setOpen(true);
+            }}
           >
             {toggle}
+            <span id={HINT_ID} className="sr-only">
+              {NO_CARD}
+            </span>
           </span>
         </TooltipTrigger>
         <TooltipContent side="left" className="max-w-56 text-center">

--- a/components/BillingPage/AutoTopUpSwitch.tsx
+++ b/components/BillingPage/AutoTopUpSwitch.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const NO_CARD = "Add a card under Payment method to turn on auto top-up.";
+
+/**
+ * The Auto top-up toggle. Without a card it is disabled and a tooltip says
+ * why: a disabled control gets no pointer events, so a focusable wrapper is
+ * the trigger, and a tap toggles it for touch screens where hover never comes.
+ */
+const AutoTopUpSwitch = ({
+  hasCard,
+  enabled,
+  onToggle,
+  isSaving,
+}: {
+  hasCard: boolean;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  isSaving: boolean;
+}) => {
+  const [open, setOpen] = useState(false);
+  const toggle = (
+    <Switch
+      checked={hasCard && enabled}
+      onCheckedChange={onToggle}
+      disabled={!hasCard || isSaving}
+      aria-label="Auto top-up"
+      className={hasCard ? undefined : "pointer-events-none"}
+    />
+  );
+  if (hasCard) return toggle;
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            data-testid="auto-top-up-no-card"
+            aria-label={NO_CARD}
+            className="inline-flex cursor-not-allowed rounded-full"
+            onClick={() => setOpen((value) => !value)}
+          >
+            {toggle}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="left" className="max-w-56 text-center">
+          {NO_CARD}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default AutoTopUpSwitch;

--- a/components/BillingPage/__tests__/AutoTopUpSwitch.test.tsx
+++ b/components/BillingPage/__tests__/AutoTopUpSwitch.test.tsx
@@ -17,12 +17,17 @@ describe("AutoTopUpSwitch", () => {
     );
     const toggle = screen.getByRole("switch");
     expect(toggle.getAttribute("disabled")).not.toBeNull();
-    expect(screen.queryAllByText(NO_CARD)).toHaveLength(0);
+    // Screen readers get the reason from the switch itself, tooltip or not.
+    const hint = document.getElementById(
+      toggle.getAttribute("aria-describedby") as string,
+    );
+    expect(hint?.textContent).toMatch(NO_CARD);
+    expect(screen.queryAllByText(NO_CARD)).toHaveLength(1);
     fireEvent.focus(screen.getByTestId("auto-top-up-no-card"));
-    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(1);
   });
 
-  it("opens the explanation on tap, for touch screens", async () => {
+  it("opens the explanation on tap and a second tap keeps it open", async () => {
     render(
       <AutoTopUpSwitch
         hasCard={false}
@@ -31,8 +36,14 @@ describe("AutoTopUpSwitch", () => {
         isSaving={false}
       />,
     );
-    fireEvent.click(screen.getByTestId("auto-top-up-no-card"));
-    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(0);
+    const trigger = screen.getByTestId("auto-top-up-no-card");
+    fireEvent.click(trigger);
+    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(1);
+    // Radix closes on pointerdown while open, then its click handler would
+    // close again; preventDefault keeps the tap an open, not a toggle.
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(1);
   });
 
   it("is a plain switch once a card is on file", () => {
@@ -46,6 +57,9 @@ describe("AutoTopUpSwitch", () => {
       />,
     );
     expect(screen.queryByTestId("auto-top-up-no-card")).toBeNull();
+    expect(
+      screen.getByRole("switch").getAttribute("aria-describedby"),
+    ).toBeNull();
     fireEvent.click(screen.getByRole("switch"));
     expect(onToggle).toHaveBeenCalledWith(true);
   });

--- a/components/BillingPage/__tests__/AutoTopUpSwitch.test.tsx
+++ b/components/BillingPage/__tests__/AutoTopUpSwitch.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import AutoTopUpSwitch from "@/components/BillingPage/AutoTopUpSwitch";
+
+const NO_CARD = /Add a card under Payment method to turn on auto top-up/;
+
+describe("AutoTopUpSwitch", () => {
+  it("is disabled without a card and explains why on focus", async () => {
+    render(
+      <AutoTopUpSwitch
+        hasCard={false}
+        enabled={false}
+        onToggle={vi.fn()}
+        isSaving={false}
+      />,
+    );
+    const toggle = screen.getByRole("switch");
+    expect(toggle.getAttribute("disabled")).not.toBeNull();
+    expect(screen.queryAllByText(NO_CARD)).toHaveLength(0);
+    fireEvent.focus(screen.getByTestId("auto-top-up-no-card"));
+    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(0);
+  });
+
+  it("opens the explanation on tap, for touch screens", async () => {
+    render(
+      <AutoTopUpSwitch
+        hasCard={false}
+        enabled={false}
+        onToggle={vi.fn()}
+        isSaving={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("auto-top-up-no-card"));
+    expect((await screen.findAllByText(NO_CARD)).length).toBeGreaterThan(0);
+  });
+
+  it("is a plain switch once a card is on file", () => {
+    const onToggle = vi.fn();
+    render(
+      <AutoTopUpSwitch
+        hasCard={true}
+        enabled={false}
+        onToggle={onToggle}
+        isSaving={false}
+      />,
+    );
+    expect(screen.queryByTestId("auto-top-up-no-card")).toBeNull();
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
Row 17 of recoupable/app#2062.

## Why

On an org with no card on file (Seeker today) the Auto top-up switch is disabled, and that read as "I don't have access" rather than "there is no card to charge". The card gate stays: a top-up charges the card on file, so there is nothing to turn on without one. The page just needs to say so where the user is looking.

## What

- `components/BillingPage/AutoTopUpSwitch.tsx` (new): the toggle. With a card it is the plain `Switch`. Without one it is disabled and wrapped in a focusable trigger with a tooltip: "Add a card under Payment method to turn on auto top-up." A disabled control receives no pointer events, so the wrapper is the trigger; hover and keyboard focus open it, and a tap toggles it for touch screens.
- `AutoTopUpPanel` renders `AutoTopUpSwitch` instead of `Switch` (still 98 lines).

No api or docs change.

## Tests

`AutoTopUpSwitch.test.tsx`: disabled without a card and the tooltip appears on focus; appears on tap; with a card it is a plain switch that toggles. Red (module missing) → green. Existing `AutoTopUpPanel` tests unchanged and passing.

## Verification

Preview walk to follow: Seeker (no card) hover, focus and tap on desktop and mobile, dark and light; Rostrum Pacific (card) shows no tooltip; screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzdC6dwcNjQrNTQEcBsmRz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tooltip to the disabled Auto top-up switch so the page explains why it's off. Previously the disabled switch read as a permissions problem; now, without a card on file, hover, keyboard focus, or a tap shows "Add a card under Payment method to turn on auto top-up," and screen readers announce the same reason. With a card, it's the same plain switch as before.

- Extracts the toggle into `AutoTopUpSwitch`; the no-card state wraps the disabled switch in a focusable trigger.
- No API, docs, or data changes.

<sup>Written for commit d6bbdb071dc0e79d995f1192e4c32aa85fde373e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an auto top-up toggle with clearer availability states.
  * Added guidance explaining that a payment card must be added before auto top-up can be enabled.
  * The toggle is disabled while settings are being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->