### PR TITLE
fix(billing): reads stay put for hours; the balance never holds the page

### DIFF
--- a/hooks/__tests__/useAccountBalance.test.tsx
+++ b/hooks/__tests__/useAccountBalance.test.tsx
@@ -8,7 +8,11 @@ import getAccountCredits from "@/lib/recoup/getAccountCredits";
 
 vi.mock("@/lib/recoup/getAccountCredits", () => ({ default: vi.fn() }));
 vi.mock("@privy-io/react-auth", () => ({
-  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+  usePrivy: () => ({
+    authenticated: true,
+    user: { id: "did:privy:test" },
+    getAccessToken: async () => "tok",
+  }),
 }));
 
 const client = new QueryClient({
@@ -39,7 +43,9 @@ describe("useAccountBalance", () => {
       wrapper,
     });
     await waitFor(() => expect(result.current.data).toBe(700));
-    expect(client.getQueryData(["credits", "balance", "acct-9"])).toBe(700);
+    expect(
+      client.getQueryData(["credits", "balance", "did:privy:test", "acct-9"]),
+    ).toBe(700);
     expect(client.getQueryData(["credits", "acct-9"])).toEqual({
       remaining_credits: 5,
     });

--- a/hooks/__tests__/useAccountQuery.test.tsx
+++ b/hooks/__tests__/useAccountQuery.test.tsx
@@ -5,8 +5,13 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import useAccountQuery from "@/hooks/useAccountQuery";
 
+let viewer = "did:privy:alice";
 vi.mock("@privy-io/react-auth", () => ({
-  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+  usePrivy: () => ({
+    authenticated: true,
+    user: { id: viewer },
+    getAccessToken: async () => "tok",
+  }),
 }));
 
 const wrap = (client: QueryClient) =>
@@ -30,7 +35,7 @@ describe("useAccountQuery", () => {
     await waitFor(() => expect(result.current.data).toEqual({ ok: true }));
     const options = client
       .getQueryCache()
-      .find({ queryKey: ["thing", "acct-1"] })?.options as {
+      .find({ queryKey: ["thing", viewer, "acct-1"] })?.options as {
       staleTime?: number;
       gcTime?: number;
       refetchOnWindowFocus?: boolean;
@@ -53,5 +58,33 @@ describe("useAccountQuery", () => {
     );
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  // A later sign-in on the same browser must never be served the earlier viewer's reads.
+  it("keys the cache by viewer as well as account", async () => {
+    const client = new QueryClient();
+    const fetcher = vi.fn(async () => ({ who: viewer }));
+    const first = renderHook(
+      () => useAccountQuery("thing", "acct-3", fetcher),
+      {
+        wrapper: wrap(client),
+      },
+    );
+    await waitFor(() =>
+      expect(first.result.current.data).toEqual({ who: "did:privy:alice" }),
+    );
+    first.unmount();
+    viewer = "did:privy:bob";
+    const second = renderHook(
+      () => useAccountQuery("thing", "acct-3", fetcher),
+      {
+        wrapper: wrap(client),
+      },
+    );
+    await waitFor(() =>
+      expect(second.result.current.data).toEqual({ who: "did:privy:bob" }),
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    viewer = "did:privy:alice";
   });
 });

--- a/hooks/__tests__/useAccountQuery.test.tsx
+++ b/hooks/__tests__/useAccountQuery.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useAccountQuery from "@/hooks/useAccountQuery";
+
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+}));
+
+const wrap = (client: QueryClient) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+
+describe("useAccountQuery", () => {
+  // Billing data changes on a scale of days; a tab switch must not reload it.
+  it("keeps data fresh for hours and never refetches on window focus", async () => {
+    const client = new QueryClient();
+    const fetcher = vi.fn(async () => ({ ok: true }));
+    const { result } = renderHook(
+      () => useAccountQuery("thing", "acct-1", fetcher),
+      {
+        wrapper: wrap(client),
+      },
+    );
+    await waitFor(() => expect(result.current.data).toEqual({ ok: true }));
+    const options = client
+      .getQueryCache()
+      .find({ queryKey: ["thing", "acct-1"] })?.options as {
+      staleTime?: number;
+      gcTime?: number;
+      refetchOnWindowFocus?: boolean;
+    };
+    expect(options.staleTime).toBeGreaterThanOrEqual(60 * 60 * 1000);
+    expect(options.gcTime).toBeGreaterThanOrEqual(60 * 60 * 1000);
+    expect(options.refetchOnWindowFocus).toBe(false);
+  });
+
+  it("does not retry a 4xx", async () => {
+    const client = new QueryClient();
+    const fetcher = vi.fn(async () => {
+      throw Object.assign(new Error("Failed: 404"), { status: 404 });
+    });
+    const { result } = renderHook(
+      () => useAccountQuery("thing", "acct-2", fetcher),
+      {
+        wrapper: wrap(client),
+      },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/__tests__/useAccountUsage.test.tsx
+++ b/hooks/__tests__/useAccountUsage.test.tsx
@@ -8,7 +8,11 @@ import getAccountUsage from "@/lib/recoup/getAccountUsage";
 
 vi.mock("@/lib/recoup/getAccountUsage", () => ({ default: vi.fn() }));
 vi.mock("@privy-io/react-auth", () => ({
-  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+  usePrivy: () => ({
+    authenticated: true,
+    user: { id: "did:privy:test" },
+    getAccessToken: async () => "tok",
+  }),
 }));
 vi.mock("@/providers/UserProvder", () => ({
   useUserProvider: () => ({ userData: { account_id: "acct-1" } }),

--- a/hooks/__tests__/useAutoTopUp.test.tsx
+++ b/hooks/__tests__/useAutoTopUp.test.tsx
@@ -8,7 +8,11 @@ import getAccountAutoTopUp from "@/lib/recoup/getAccountAutoTopUp";
 
 vi.mock("@/lib/recoup/getAccountAutoTopUp", () => ({ default: vi.fn() }));
 vi.mock("@privy-io/react-auth", () => ({
-  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+  usePrivy: () => ({
+    authenticated: true,
+    user: { id: "did:privy:test" },
+    getAccessToken: async () => "tok",
+  }),
 }));
 
 const makeWrapper = () => {

--- a/hooks/__tests__/useBillingMutations.test.tsx
+++ b/hooks/__tests__/useBillingMutations.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useBillingMutations from "@/hooks/useBillingMutations";
+
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({
+    user: { id: "did:privy:alice" },
+    getAccessToken: async () => "tok",
+  }),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/billing/updateClientAutoTopUp", () => ({
+  default: vi.fn(async () => ({ enabled: true })),
+}));
+
+describe("useBillingMutations", () => {
+  // Read keys are [key, viewer, account]; a save must not disturb other accounts' caches.
+  it("invalidates only this viewer's read for this account after a save", async () => {
+    const client = new QueryClient();
+    client.setQueryData(["autoTopUp", "did:privy:alice", "acct-1"], {
+      enabled: false,
+    });
+    client.setQueryData(["autoTopUp", "did:privy:alice", "acct-2"], {
+      enabled: false,
+    });
+    client.setQueryData(["autoTopUp", "did:privy:bob", "acct-1"], {
+      enabled: false,
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useBillingMutations("acct-1"), {
+      wrapper,
+    });
+
+    await act(async () => {
+      result.current.saveAutoTopUp.mutate({
+        enabled: true,
+        amountCents: 500,
+        thresholdCents: 100,
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.saveAutoTopUp.isSuccess).toBe(true),
+    );
+
+    const stale = (key: unknown[]) => client.getQueryState(key)?.isInvalidated;
+    expect(stale(["autoTopUp", "did:privy:alice", "acct-1"])).toBe(true);
+    expect(stale(["autoTopUp", "did:privy:alice", "acct-2"])).toBe(false);
+    expect(stale(["autoTopUp", "did:privy:bob", "acct-1"])).toBe(false);
+  });
+});

--- a/hooks/__tests__/useBillingReads.test.tsx
+++ b/hooks/__tests__/useBillingReads.test.tsx
@@ -67,18 +67,6 @@ describe("useBillingReads", () => {
     expect(result.current.balanceUsd).toBe("$12.40");
   });
 
-  it("keeps the page loading while the balance is still loading", () => {
-    reads.balance = {
-      data: undefined,
-      isLoading: true,
-      error: null,
-      isError: false,
-    };
-    const { result } = renderHook(() => useBillingReads("acct-1"));
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.ready).toBe(false);
-  });
-
   it("reports no balance rather than $0.00 when the read failed", () => {
     reads.balance = {
       data: undefined,
@@ -99,6 +87,19 @@ describe("useBillingReads", () => {
       isError: true,
     };
     const { result } = renderHook(() => useBillingReads("acct-1"));
+    expect(result.current.balanceUsd).toBeNull();
+  });
+
+  it("is ready while the balance is still loading: the balance never gates the page", () => {
+    reads.balance = {
+      data: undefined,
+      isLoading: true,
+      error: null,
+      isError: false,
+    };
+    const { result } = renderHook(() => useBillingReads("acct-1"));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.ready).toBe(true);
     expect(result.current.balanceUsd).toBeNull();
   });
 });

--- a/hooks/__tests__/usePayments.test.tsx
+++ b/hooks/__tests__/usePayments.test.tsx
@@ -8,7 +8,11 @@ import getAccountPayments from "@/lib/recoup/getAccountPayments";
 
 vi.mock("@/lib/recoup/getAccountPayments", () => ({ default: vi.fn() }));
 vi.mock("@privy-io/react-auth", () => ({
-  usePrivy: () => ({ authenticated: true, getAccessToken: async () => "tok" }),
+  usePrivy: () => ({
+    authenticated: true,
+    user: { id: "did:privy:test" },
+    getAccessToken: async () => "tok",
+  }),
 }));
 
 const makeWrapper = () => {

--- a/hooks/useAccountBalance.ts
+++ b/hooks/useAccountBalance.ts
@@ -1,11 +1,21 @@
 import useAccountQuery from "@/hooks/useAccountQuery";
 import getAccountCredits from "@/lib/recoup/getAccountCredits";
 
-/** Remaining credits for an account (own or a member org), for the auto top-up panel. */
+/**
+ * Remaining credits for an account (own or a member org), for the auto top-up
+ * panel. Unlike the card and plan, the balance moves with every task, so it
+ * goes stale after five minutes and refreshes on tab focus; it never holds the
+ * page, so that refresh is invisible.
+ */
 const useAccountBalance = (accountId: string | undefined) =>
-  useAccountQuery(["credits", "balance"], accountId, async (id, token) => {
-    const credits = await getAccountCredits(id, token);
-    return credits.remaining_credits;
-  });
+  useAccountQuery(
+    ["credits", "balance"],
+    accountId,
+    async (id, token) => {
+      const credits = await getAccountCredits(id, token);
+      return credits.remaining_credits;
+    },
+    { staleTime: 5 * 60 * 1000, refetchOnWindowFocus: true },
+  );
 
 export default useAccountBalance;

--- a/hooks/useAccountQuery.ts
+++ b/hooks/useAccountQuery.ts
@@ -1,14 +1,17 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
+import isClientError from "@/lib/api/isClientError";
 
 type Fetcher<T> = (accountId: string, accessToken: string) => Promise<T>;
 
-/** The shared shape of the billing reads: one key per account, Privy bearer, a minute of freshness. */
+/** Billing changes on a scale of days: keep a read for six hours, and never reload it on tab focus. */
+const BILLING_READ_TTL = 6 * 60 * 60 * 1000;
+
+/** The shared shape of the billing reads: one key per account, Privy bearer, sticky for hours. */
 const useAccountQuery = <T>(
   key: string | string[],
   accountId: string | undefined,
   fetcher: Fetcher<T>,
-  options: { refetchOnWindowFocus?: boolean; retry?: number | boolean } = {},
 ): UseQueryResult<T> => {
   const { getAccessToken, authenticated } = usePrivy();
   return useQuery({
@@ -19,9 +22,11 @@ const useAccountQuery = <T>(
       return fetcher(accountId as string, accessToken);
     },
     enabled: authenticated && !!accountId,
-    staleTime: 60 * 1000,
-    refetchOnWindowFocus: options.refetchOnWindowFocus ?? true,
-    retry: options.retry ?? 3,
+    staleTime: BILLING_READ_TTL,
+    gcTime: BILLING_READ_TTL,
+    refetchOnWindowFocus: false,
+    // A 4xx will not change on retry; only network and server errors are worth a second try.
+    retry: (failureCount, error) => !isClientError(error) && failureCount < 2,
   });
 };
 

--- a/hooks/useAccountQuery.ts
+++ b/hooks/useAccountQuery.ts
@@ -1,30 +1,33 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import isClientError from "@/lib/api/isClientError";
+import BILLING_READ_TTL from "@/lib/billing/billingReadTtl";
 
 type Fetcher<T> = (accountId: string, accessToken: string) => Promise<T>;
 
-/** Billing changes on a scale of days: keep a read for six hours, and never reload it on tab focus. */
-const BILLING_READ_TTL = 6 * 60 * 60 * 1000;
-
-/** The shared shape of the billing reads: one key per account, Privy bearer, sticky for hours. */
+/**
+ * The shared shape of the billing reads: keyed by viewer and account (a later
+ * sign-in on the same browser never sees an earlier viewer's cache), Privy
+ * bearer, sticky for hours unless the caller asks for fresher data.
+ */
 const useAccountQuery = <T>(
   key: string | string[],
   accountId: string | undefined,
   fetcher: Fetcher<T>,
+  options: { staleTime?: number; refetchOnWindowFocus?: boolean } = {},
 ): UseQueryResult<T> => {
-  const { getAccessToken, authenticated } = usePrivy();
+  const { getAccessToken, authenticated, user } = usePrivy();
   return useQuery({
-    queryKey: [...(Array.isArray(key) ? key : [key]), accountId],
+    queryKey: [...(Array.isArray(key) ? key : [key]), user?.id, accountId],
     queryFn: async () => {
       const accessToken = await getAccessToken();
       if (!accessToken) throw new Error("Please sign in to load billing");
       return fetcher(accountId as string, accessToken);
     },
-    enabled: authenticated && !!accountId,
-    staleTime: BILLING_READ_TTL,
+    enabled: authenticated && !!user?.id && !!accountId,
+    staleTime: options.staleTime ?? BILLING_READ_TTL,
     gcTime: BILLING_READ_TTL,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: options.refetchOnWindowFocus ?? false,
     // A 4xx will not change on retry; only network and server errors are worth a second try.
     retry: (failureCount, error) => !isClientError(error) && failureCount < 2,
   });

--- a/hooks/useAutoTopUp.ts
+++ b/hooks/useAutoTopUp.ts
@@ -1,8 +1,8 @@
 import useAccountQuery from "@/hooks/useAccountQuery";
 import getAccountAutoTopUp from "@/lib/recoup/getAccountAutoTopUp";
 
-/** The opt-in auto top-up settings for an account; one retry so a blip does not disable the panel. */
+/** The opt-in auto top-up settings for an account. */
 const useAutoTopUp = (accountId: string | undefined) =>
-  useAccountQuery("autoTopUp", accountId, getAccountAutoTopUp, { retry: 1 });
+  useAccountQuery("autoTopUp", accountId, getAccountAutoTopUp);
 
 export default useAutoTopUp;

--- a/hooks/useBillingMutations.ts
+++ b/hooks/useBillingMutations.ts
@@ -16,7 +16,7 @@ const describe = (error: unknown) =>
 
 /** The billing page's writes for one account; every failure becomes a toast. */
 const useBillingMutations = (accountId: string | undefined) => {
-  const { getAccessToken } = usePrivy();
+  const { getAccessToken, user } = usePrivy();
   const queryClient = useQueryClient();
 
   const withToken = async <T>(fn: (token: string) => Promise<T>) => {
@@ -24,9 +24,9 @@ const useBillingMutations = (accountId: string | undefined) => {
     if (!token || !accountId) throw new Error("Please sign in");
     return fn(token);
   };
-  // Prefix match: the read keys carry the viewer id before the account id.
+  // Same shape as the read keys: only this viewer's reads for this account go stale.
   const invalidate = (key: string) =>
-    queryClient.invalidateQueries({ queryKey: [key] });
+    queryClient.invalidateQueries({ queryKey: [key, user?.id, accountId] });
   const open =
     (
       label: string,

--- a/hooks/useBillingMutations.ts
+++ b/hooks/useBillingMutations.ts
@@ -24,8 +24,9 @@ const useBillingMutations = (accountId: string | undefined) => {
     if (!token || !accountId) throw new Error("Please sign in");
     return fn(token);
   };
+  // Prefix match: the read keys carry the viewer id before the account id.
   const invalidate = (key: string) =>
-    queryClient.invalidateQueries({ queryKey: [key, accountId] });
+    queryClient.invalidateQueries({ queryKey: [key] });
   const open =
     (
       label: string,

--- a/hooks/useBillingReads.ts
+++ b/hooks/useBillingReads.ts
@@ -22,13 +22,13 @@ const useBillingReads = (accountId: string | undefined) => {
   const autoTopUp = useAutoTopUp(accountId);
   const balance = useAccountBalance(accountId);
 
-  // Auto top-up and the balance are in the gate so the panel never shows Off or $0.00 while they load.
+  // Auto top-up is in the gate so the panel never shows Off while it loads; the
+  // balance is display-only and never holds the page (its hint reads "unavailable" until it lands).
   const isLoading =
     paymentMethod.isLoading ||
     subscription.isLoading ||
     payments.isLoading ||
-    autoTopUp.isLoading ||
-    balance.isLoading;
+    autoTopUp.isLoading;
   const failed = paymentMethod.error || subscription.error || payments.error;
   // The api enforces access: a 403 on any read means the caller may not see this account.
   const forbidden = [

--- a/hooks/usePayments.ts
+++ b/hooks/usePayments.ts
@@ -5,21 +5,20 @@ import {
 } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import isClientError from "@/lib/api/isClientError";
+import BILLING_READ_TTL from "@/lib/billing/billingReadTtl";
 import getAccountPayments, {
   AccountPaymentsPage,
 } from "@/lib/recoup/getAccountPayments";
 
 const PAGE_SIZE = 20;
-/** Same stickiness as the other billing reads (see useAccountQuery). */
-const BILLING_READ_TTL = 6 * 60 * 60 * 1000;
 
 /** An account's invoices, newest first, paged by the last id. */
 const usePayments = (
   accountId: string | undefined,
 ): UseInfiniteQueryResult<InfiniteData<AccountPaymentsPage>> => {
-  const { getAccessToken, authenticated } = usePrivy();
+  const { getAccessToken, authenticated, user } = usePrivy();
   return useInfiniteQuery({
-    queryKey: ["payments", accountId],
+    queryKey: ["payments", user?.id, accountId],
     initialPageParam: undefined as string | undefined,
     queryFn: async ({ pageParam }) => {
       const accessToken = await getAccessToken();
@@ -31,7 +30,7 @@ const usePayments = (
     },
     getNextPageParam: (lastPage) =>
       lastPage.hasMore ? lastPage.payments.at(-1)?.id : undefined,
-    enabled: authenticated && !!accountId,
+    enabled: authenticated && !!user?.id && !!accountId,
     staleTime: BILLING_READ_TTL,
     gcTime: BILLING_READ_TTL,
     refetchOnWindowFocus: false,

--- a/hooks/usePayments.ts
+++ b/hooks/usePayments.ts
@@ -4,11 +4,14 @@ import {
   InfiniteData,
 } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
+import isClientError from "@/lib/api/isClientError";
 import getAccountPayments, {
   AccountPaymentsPage,
 } from "@/lib/recoup/getAccountPayments";
 
 const PAGE_SIZE = 20;
+/** Same stickiness as the other billing reads (see useAccountQuery). */
+const BILLING_READ_TTL = 6 * 60 * 60 * 1000;
 
 /** An account's invoices, newest first, paged by the last id. */
 const usePayments = (
@@ -29,8 +32,10 @@ const usePayments = (
     getNextPageParam: (lastPage) =>
       lastPage.hasMore ? lastPage.payments.at(-1)?.id : undefined,
     enabled: authenticated && !!accountId,
-    staleTime: 60 * 1000,
+    staleTime: BILLING_READ_TTL,
+    gcTime: BILLING_READ_TTL,
     refetchOnWindowFocus: false,
+    retry: (failureCount, error) => !isClientError(error) && failureCount < 2,
   });
 };
 

--- a/lib/api/isClientError.ts
+++ b/lib/api/isClientError.ts
@@ -1,0 +1,7 @@
+/** True for an error carrying an HTTP 4xx `status`, the way the account fetchers throw. */
+const isClientError = (error: unknown): boolean => {
+  const status = (error as { status?: unknown } | null)?.status;
+  return typeof status === "number" && status >= 400 && status < 500;
+};
+
+export default isClientError;

--- a/lib/billing/billingReadTtl.ts
+++ b/lib/billing/billingReadTtl.ts
@@ -1,0 +1,4 @@
+/** Billing changes on a scale of days: keep a read for six hours, and never reload it on tab focus. */
+const BILLING_READ_TTL = 6 * 60 * 60 * 1000;
+
+export default BILLING_READ_TTL;

--- a/lib/recoup/getAccountCredits.ts
+++ b/lib/recoup/getAccountCredits.ts
@@ -33,7 +33,10 @@ async function getAccountCredits(
   );
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch credits: ${response.status}`);
+    throw Object.assign(
+      new Error(`Failed to fetch credits: ${response.status}`),
+      { status: response.status },
+    );
   }
 
   return response.json();


### PR DESCRIPTION
Row 18 of recoupable/app#2062.

## Why

On prod, signed in as Sweets ([request log](https://github.com/recoupable/app/issues/2062#issuecomment-5562082145)): every return to the tab refetched four of the five billing reads (60 s `staleTime`, focus refetch on), and the balance read, which 404s for an org with no credits row, had no cached data, so its three-retry chain put the whole page back into the skeleton for 8 s. Billing data changes on a scale of days.

## What

- `useAccountQuery` and `usePayments`: six-hour `staleTime` and `gcTime`, `refetchOnWindowFocus: false`, retry only errors that are not 4xx (`lib/api/isClientError.ts`, one export). Saves still refetch through `invalidateQueries` in `useBillingMutations`; Stripe round trips are full navigations, so they always start cold.
- `getAccountCredits` attaches the HTTP `status` to its error like the other fetchers, so a 4xx is recognised (this also closes the gap cubic raised on #2067).
- `useBillingReads`: the balance leaves the skeleton gate; auto top-up stays in it. A missing balance reads "unavailable" in the hint, nothing else waits for it.

The api side of the same symptom (the 404 itself) is recoupable/api#905, row 19.

## Tests

`useAccountQuery.test.tsx` (new): hours-scale freshness, no focus refetch, a 404 is fetched exactly once. `useBillingReads.test.tsx`: ready while the balance is still loading. Both red → green; 109 billing tests pass.

## Verification

Prod-style walk to follow on the preview: request log on cold load, then tab away and back, expecting the five reads once and nothing on focus, with content staying on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzdC6dwcNjQrNTQEcBsmRz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the billing page from dropping into its loading skeleton on every tab return and on a 404 balance read. Billing reads now stay cached for six hours, skip focus refetches, and retry only errors that aren't 4xx.

- Reads are keyed by viewer and account, so a later sign-in never sees the previous viewer's cache; saves invalidate by that key so only this account's reads for this viewer go stale.
- The balance read keeps a five-minute freshness window and refreshes on focus, but never holds the page; it shows "unavailable" until it lands.
- Auto top-up still gates page readiness.
- `getAccountCredits` attaches the HTTP `status` to thrown errors so its 404 is recognized as a client error.
- Adds coverage for hour-scale freshness, no focus refetch, viewer-keyed caching, scoped invalidation, a single fetch on 404, and the balance not blocking the page.

<sup>Written for commit 8cf560c739fc3ebfa20cb79270a960af7c059ba8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Billing data is now cached per signed-in viewer for up to six hours, reducing unnecessary refreshes.
  - Billing pages no longer wait for account balance data before displaying other billing details.
  - Client-side errors are no longer retried automatically, while eligible temporary failures receive limited retry attempts.
  - Credit-related errors now retain their HTTP status for more accurate handling and messaging.
  - Account balances refresh when the browser window regains focus, while other billing data remains cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->