### PR TITLE
feat(billing): Configure billing shows a spinner while checkout opens, and a pointer on hover

### DIFF
--- a/components/BillingPage/BillingPage.tsx
+++ b/components/BillingPage/BillingPage.tsx
@@ -56,9 +56,10 @@ const BillingPage = ({
           <div className="mb-4 flex flex-col gap-4 md:flex-row">
             <PaymentMethodPanel
               card={card}
-              onConfigure={actions.configureCard}
+              onConfigure={() => actions.configureCard.mutate()}
               onRemove={() => actions.removeCard.mutate()}
               isBusy={actions.removeCard.isPending}
+              isConfiguring={actions.configureCard.isPending}
               onSwitchToPersonal={
                 isOrg && !forced ? scope.switchToPersonal : undefined
               }

--- a/components/BillingPage/PaymentMethodPanel.tsx
+++ b/components/BillingPage/PaymentMethodPanel.tsx
@@ -1,5 +1,6 @@
 import { CreditCard } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import BillingPanel from "./BillingPanel";
 import RemoveCardButton from "./RemoveCardButton";
 import type { SavedCard } from "@/lib/recoup/getAccountPaymentMethod";
@@ -13,12 +14,15 @@ const PaymentMethodPanel = ({
   onConfigure,
   onRemove,
   isBusy,
+  isConfiguring = false,
   onSwitchToPersonal,
 }: {
   card: SavedCard | null;
   onConfigure: () => void;
   onRemove: () => void;
   isBusy: boolean;
+  /** True from the click until the Stripe page loads; the label becomes a spinner. */
+  isConfiguring?: boolean;
   /** Present when an organization is selected; returns the page to personal billing. */
   onSwitchToPersonal?: () => void;
 }) => (
@@ -43,9 +47,9 @@ const PaymentMethodPanel = ({
             variant="outline"
             size="sm"
             onClick={onConfigure}
-            disabled={isBusy}
+            disabled={isBusy || isConfiguring}
           >
-            Replace card
+            {isConfiguring ? <Spinner /> : "Replace card"}
           </Button>
           <RemoveCardButton onRemove={onRemove} disabled={isBusy} />
         </div>
@@ -57,8 +61,8 @@ const PaymentMethodPanel = ({
           plan.
         </p>
         <div className="flex flex-wrap items-center gap-3">
-          <Button onClick={onConfigure} disabled={isBusy}>
-            Configure billing
+          <Button onClick={onConfigure} disabled={isBusy || isConfiguring}>
+            {isConfiguring ? <Spinner /> : "Configure billing"}
           </Button>
         </div>
       </>

--- a/components/BillingPage/__tests__/BillingPage.denied.test.tsx
+++ b/components/BillingPage/__tests__/BillingPage.denied.test.tsx
@@ -6,7 +6,7 @@ import BillingPage from "@/components/BillingPage/BillingPage";
 const scope = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
 const reads = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
 const mutations = vi.hoisted(() => ({
-  configureCard: vi.fn(),
+  configureCard: { mutate: vi.fn(), isPending: false },
   upgrade: vi.fn(),
   manageBilling: vi.fn(),
   removeCard: { mutate: vi.fn(), isPending: false },

--- a/components/BillingPage/__tests__/BillingPage.test.tsx
+++ b/components/BillingPage/__tests__/BillingPage.test.tsx
@@ -47,7 +47,7 @@ vi.mock("@/hooks/useBillingScope", () => ({ default: () => scope }));
 vi.mock("@/hooks/useBillingReads", () => ({ default: () => reads }));
 vi.mock("@/hooks/useBillingMutations", () => ({
   default: () => ({
-    configureCard: vi.fn(),
+    configureCard: { mutate: vi.fn(), isPending: false },
     upgrade: vi.fn(),
     manageBilling: vi.fn(),
     removeCard: mutation,

--- a/components/BillingPage/__tests__/PaymentMethodPanel.test.tsx
+++ b/components/BillingPage/__tests__/PaymentMethodPanel.test.tsx
@@ -65,4 +65,20 @@ describe("PaymentMethodPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Configure billing" }));
     expect(onConfigure).toHaveBeenCalled();
   });
+
+  it("swaps the Configure billing label for a spinner while the session is created", () => {
+    render(
+      <PaymentMethodPanel
+        card={null}
+        onConfigure={vi.fn()}
+        onRemove={vi.fn()}
+        isBusy={false}
+        isConfiguring={true}
+      />,
+    );
+    const button = screen.getByRole("button", { name: /loading/i });
+    expect(button.getAttribute("disabled")).not.toBeNull();
+    expect(screen.queryByText("Configure billing")).toBeNull();
+    expect(button.querySelector("[role=status]")).not.toBeNull();
+  });
 });

--- a/components/ui/__tests__/button.test.tsx
+++ b/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,13 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "@/components/ui/button";
+
+// Tailwind v4's preflight gives <button> cursor: default; a clickable button must show a pointer.
+describe("Button", () => {
+  it("shows a pointer cursor", () => {
+    render(<Button>Configure billing</Button>);
+    expect(screen.getByRole("button").className).toContain("cursor-pointer");
+  });
+});

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** shadcn Spinner: an accessible spinning loader, sized to sit in place of button text. */
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };

--- a/hooks/__tests__/useBillingMutations.test.tsx
+++ b/hooks/__tests__/useBillingMutations.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@/lib/billing/updateClientAutoTopUp", () => ({
   default: vi.fn(async () => ({ enabled: true })),
 }));
 vi.mock("@/lib/billing/createClientPaymentMethodSession", () => ({
-  default: vi.fn(() => new Promise(() => {})),
+  default: vi.fn(async () => ({})),
 }));
 
 describe("useBillingMutations", () => {
@@ -56,8 +56,10 @@ describe("useBillingMutations", () => {
     expect(stale(["autoTopUp", "did:privy:bob", "acct-1"])).toBe(false);
   });
 
-  // Stripe checkout opens in the same tab; the button shows a spinner until then.
-  it("reports configureCard as pending while the checkout session is being created", async () => {
+  // Stripe checkout opens in the same tab: the helper calls location.assign and
+  // resolves at once, so the mutation must stay pending until the page unloads,
+  // or a slow navigation would re-enable the button and allow a second session.
+  it("keeps configureCard pending after the session resolves, until the page unloads", async () => {
     const client = new QueryClient();
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={client}>{children}</QueryClientProvider>

--- a/hooks/__tests__/useBillingMutations.test.tsx
+++ b/hooks/__tests__/useBillingMutations.test.tsx
@@ -15,6 +15,9 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/lib/billing/updateClientAutoTopUp", () => ({
   default: vi.fn(async () => ({ enabled: true })),
 }));
+vi.mock("@/lib/billing/createClientPaymentMethodSession", () => ({
+  default: vi.fn(() => new Promise(() => {})),
+}));
 
 describe("useBillingMutations", () => {
   // Read keys are [key, viewer, account]; a save must not disturb other accounts' caches.
@@ -51,5 +54,21 @@ describe("useBillingMutations", () => {
     expect(stale(["autoTopUp", "did:privy:alice", "acct-1"])).toBe(true);
     expect(stale(["autoTopUp", "did:privy:alice", "acct-2"])).toBe(false);
     expect(stale(["autoTopUp", "did:privy:bob", "acct-1"])).toBe(false);
+  });
+
+  // Stripe checkout opens in the same tab; the button shows a spinner until then.
+  it("reports configureCard as pending while the checkout session is being created", async () => {
+    const client = new QueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useBillingMutations("acct-1"), {
+      wrapper,
+    });
+    expect(result.current.configureCard.isPending).toBe(false);
+    act(() => result.current.configureCard.mutate());
+    await waitFor(() =>
+      expect(result.current.configureCard.isPending).toBe(true),
+    );
   });
 });

--- a/hooks/useBillingMutations.ts
+++ b/hooks/useBillingMutations.ts
@@ -71,6 +71,9 @@ const useBillingMutations = (accountId: string | undefined) => {
           token,
         );
         if (result?.error) throw new Error(describe(result.error));
+        // The helper has already called location.assign: this tab is unloading
+        // into Stripe, so stay pending rather than re-enable the button first.
+        await new Promise<never>(() => {});
       }),
     onError: (error) =>
       toast.error(`Could not open checkout: ${describe(error)}`),

--- a/hooks/useBillingMutations.ts
+++ b/hooks/useBillingMutations.ts
@@ -62,10 +62,22 @@ const useBillingMutations = (accountId: string | undefined) => {
     },
   });
 
+  // A mutation rather than `open` so the panel can show a spinner until the Stripe page loads.
+  const configureCard = useMutation({
+    mutationFn: () =>
+      withToken(async (token) => {
+        const result = await createClientPaymentMethodSession(
+          accountId as string,
+          token,
+        );
+        if (result?.error) throw new Error(describe(result.error));
+      }),
+    onError: (error) =>
+      toast.error(`Could not open checkout: ${describe(error)}`),
+  });
+
   return {
-    configureCard: open("Could not open checkout", (token) =>
-      createClientPaymentMethodSession(accountId as string, token),
-    ),
+    configureCard,
     upgrade: open("Could not open checkout", (token) =>
       createClientCheckoutSession(token),
     ),


### PR DESCRIPTION
Row 20 of recoupable/app#2062.

## Why

Clicking Configure billing gave no feedback until the Stripe page loaded (the session is created, then the tab navigates), and hovering it showed no pointer. The pointer is a Tailwind v4 preflight default (`button { cursor: default }`) that the shared Button never overrode, so it affected every button in the app.

## What

- `hooks/useBillingMutations.ts`: `configureCard` is a `useMutation` (was the fire-and-forget `open` helper), so the page has `isPending` from the click until the tab unloads into Stripe. Errors still toast.
- `components/BillingPage/PaymentMethodPanel.tsx`: new `isConfiguring` prop; Configure billing and Replace card render the shadcn `Spinner` in place of their label and are disabled while it is true.
- `components/ui/spinner.tsx` (new): the shadcn Spinner (`Loader2Icon`, `role="status"`, `aria-label="Loading"`).
- `components/ui/button.tsx`: base classes gain `cursor-pointer`. One class, every button.

## Tests

`PaymentMethodPanel.test.tsx`: label replaced by a `role=status` spinner and the button disabled while configuring. `useBillingMutations.test.tsx`: `configureCard.isPending` is true while session creation is in flight. `button.test.tsx` (new): the pointer class. All red → green; 108 tests pass.

## Verification

Preview walk to follow: click Configure billing on Seeker and capture the spinner before the Stripe page loads, hover shows a pointer, dark + light, desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzdC6dwcNjQrNTQEcBsmRz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a spinner on Configure billing and Replace card while the Stripe checkout session opens, and gives every button in the app a pointer on hover.

- `configureCard` is now a mutation; the panel swaps the label for a spinner and disables the button from click until the Stripe page loads, with errors still toasting. The mutation stays pending after the session resolves since the tab is already navigating away, so the button can't be re-enabled and clicked twice.
- Tailwind v4's preflight gave buttons `cursor: default`; the shared `Button` now includes `cursor-pointer`.

<sup>Written for commit 77548f96e191848a70be25e6ead89c50eeed015e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Billing payment actions now display a loading indicator while configuration is in progress.
  * “Replace card” and “Configure billing” buttons are disabled during active operations to prevent duplicate actions.
* **Style**
  * Buttons now display a pointer cursor when interactive.
* **Bug Fixes**
  * Improved billing action handling so the interface remains in a clear loading state until the payment setup page opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->