### PR TITLE
feat(plan): "Tracks analyzed a month" row on the plan table

### DIFF
--- a/lib/plan/__tests__/planTable.test.ts
+++ b/lib/plan/__tests__/planTable.test.ts
@@ -13,6 +13,7 @@ describe("plan table", () => {
       "Report runs that buys",
       "Scheduled tasks",
       "Fastest cadence",
+      "Tracks analyzed a month",
       "Reports emailed to",
       "API keys",
       "Daily social monitoring",
@@ -26,6 +27,7 @@ describe("plan table", () => {
     expect(byLabel["Report runs that buys"]).toEqual(["~4", "~26", "~391"]);
     expect(byLabel["Scheduled tasks"]).toEqual(["1", "3", "Unlimited"]);
     expect(byLabel["Fastest cadence"]).toEqual(["Weekly", "Daily", "Hourly"]);
+    expect(byLabel["Tracks analyzed a month"]).toEqual(["5", "Unlimited", "Unlimited"]);
     expect(byLabel["Reports emailed to"]).toEqual(["You", "You", "Anyone"]);
     expect(byLabel["API keys"]).toEqual(["check", "check", "check"]);
     expect(byLabel["Daily social monitoring"]).toEqual(["dash", "dash", "check"]);

--- a/lib/plan/planTable.ts
+++ b/lib/plan/planTable.ts
@@ -31,6 +31,7 @@ export const PLAN_TABLE_ROWS: PlanTableRow[] = [
   { label: "Report runs that buys", mobileLabel: "Report runs", cells: ["~4", "~26", "~391"] },
   { label: "Scheduled tasks", mobileLabel: "Tasks", cells: ["1", "3", "Unlimited"] },
   { label: "Fastest cadence", mobileLabel: "Fastest cadence", cells: ["Weekly", "Daily", "Hourly"] },
+  { label: "Tracks analyzed a month", mobileLabel: "Tracks analyzed", cells: ["5", "Unlimited", "Unlimited"] },
   { label: "Reports emailed to", mobileLabel: "Reports emailed to", cells: ["You", "You", "Anyone"] },
   { label: "API keys", mobileLabel: "API keys", cells: ["check", "check", "check"] },
   { label: "Daily social monitoring", mobileLabel: "Social monitoring", cells: ["dash", "dash", "check"] },


### PR DESCRIPTION
Item "free tier: 5 analyze requests per calendar month" of recoupable/app#2061. Shows the cap as a plan benefit on `/plan`. **Merge after recoupable/api#909** (the gate) so the page never promises a cap the api does not enforce; contract in recoupable/docs#337.

## What changes

One row in `lib/plan/planTable.ts`, after "Fastest cadence":

| | Free | Starter | Pro |
|---|---|---|---|
| Tracks analyzed a month (mobile: Tracks analyzed) | 5 | Unlimited | Unlimited |

`planTable.test.ts` pins the row order and cells (red before green). The marketing `/pricing` comparison table mirrors these labels in its own PR so the two surfaces stay in sync.

Preview screenshots (desktop + mobile, dark + light) to follow in a comment once the deployment is Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194KNv9zWevLUxi84wPs2TN


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Tracks analyzed a month" row to the plan table on `/plan`, showing 5 for Free and Unlimited for Starter and Pro, making the analyze request cap visible as a plan benefit. The row is placed after "Fastest cadence" and the test suite pins its position and values. This change depends on the API gate that enforces the cap, so merge only after `recoupable/api#909`.

<sup>Written for commit 05f2b1744da89a95abbdff2809f1d936fee732b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/app/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Tracks analyzed a month” comparison row to the plan comparison table.
  - Displays monthly limits for Free, Starter, and Pro plans: 5, Unlimited, and Unlimited respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->